### PR TITLE
Windows support for send/receive tardiffs.

### DIFF
--- a/diskwriter_linux.go
+++ b/diskwriter_linux.go
@@ -1,0 +1,62 @@
+package fsutil
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/stevvooe/continuity/sysx"
+	"golang.org/x/sys/unix"
+)
+
+func rewriteMetadata(p string, stat *Stat) error {
+	for key, value := range stat.Xattrs {
+		sysx.Setxattr(p, key, value, 0)
+	}
+
+	if err := os.Lchown(p, int(stat.Uid), int(stat.Gid)); err != nil {
+		return errors.Wrapf(err, "failed to lchown %s", p)
+	}
+
+	if os.FileMode(stat.Mode)&os.ModeSymlink == 0 {
+		if err := os.Chmod(p, os.FileMode(stat.Mode)); err != nil {
+			return errors.Wrapf(err, "failed to chown %s", p)
+		}
+	}
+
+	if err := chtimes(p, stat.ModTime); err != nil {
+		return errors.Wrapf(err, "failed to chtimes %s", p)
+	}
+
+	return nil
+}
+
+func chtimes(path string, un int64) error {
+	var utimes [2]unix.Timespec
+	utimes[0] = unix.NsecToTimespec(un)
+	utimes[1] = utimes[0]
+
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, path, utimes[0:], unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.Wrap(err, "failed call to UtimesNanoAt")
+	}
+
+	return nil
+}
+
+// handleTarTypeBlockCharFifo is an OS-specific helper function used by
+// createTarFile to handle the following types of header: Block; Char; Fifo
+func handleTarTypeBlockCharFifo(path string, stat *Stat) error {
+	mode := uint32(stat.Mode & 07777)
+	if os.FileMode(stat.Mode)&os.ModeCharDevice != 0 {
+		mode |= syscall.S_IFCHR
+	} else if os.FileMode(stat.Mode)&os.ModeNamedPipe != 0 {
+		mode |= syscall.S_IFIFO
+	} else {
+		mode |= syscall.S_IFBLK
+	}
+
+	if err := syscall.Mknod(path, mode, int(mkdev(stat.Devmajor, stat.Devminor))); err != nil {
+		return err
+	}
+	return nil
+}

--- a/diskwriter_windows.go
+++ b/diskwriter_windows.go
@@ -1,0 +1,24 @@
+package fsutil
+
+import (
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func rewriteMetadata(p string, stat *Stat) error {
+	return chtimes(p, stat.ModTime)
+}
+
+func chtimes(path string, un int64) error {
+
+	mtime := time.Unix(0, un)
+	return os.Chtimes(path, mtime, mtime)
+}
+
+// handleTarTypeBlockCharFifo is an OS-specific helper function used by
+// createTarFile to handle the following types of header: Block; Char; Fifo
+func handleTarTypeBlockCharFifo(path string, stat *Stat) error {
+	return errors.New("Not implemented on windows")
+}

--- a/receive.go
+++ b/receive.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package fsutil
 
 import (

--- a/send.go
+++ b/send.go
@@ -1,11 +1,10 @@
-// +build linux
-
 package fsutil
 
 import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -112,6 +111,11 @@ func (s *sender) send() error {
 		stat, ok := fi.Sys().(*Stat)
 		if !ok {
 			return errors.Wrapf(err, "invalid fileinfo without stat info: %s", path)
+		}
+		if runtime.GOOS == "windows" {
+			stat.Mode &= 0755
+			// Add the x bit: make everything +x from windows
+			stat.Mode |= 0111
 		}
 		p := &Packet{
 			Type: PACKET_STAT,

--- a/walker.go
+++ b/walker.go
@@ -40,6 +40,9 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	seenFiles := make(map[uint64]string)
 	return filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return filepath.SkipDir
+			}
 			return err
 		}
 		origpath := path


### PR DESCRIPTION
This add supports for Windows for diskwriter and send/receive components.
This is key to enable context streaming / tardiffs on Windows.

2 scenarios remain to test: windows client -> linux daemon and linux
client -> windows daemon.
