### PR TITLE
receive: read stream to EOF on close

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -198,7 +198,15 @@ func (r *receiver) run(ctx context.Context) error {
 					}
 				}
 			case PACKET_FIN:
-				return nil
+				for {
+					var p Packet
+					if err := r.conn.RecvMsg(&p); err != nil {
+						if err == io.EOF {
+							return nil
+						}
+						return err
+					}
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Make sure the grpc stream is fully read. Otherwise, stream completes with an error for the monitoring tools when the context is canceled.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>