### PR TITLE
copy: Fixes bug when relative destination does not have a directory component

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -30,8 +30,10 @@ func Copy(ctx context.Context, src, dst string, opts ...Opt) error {
 	if d, f := filepath.Split(dst); f != "" && f != "." {
 		ensureDstPath = d
 	}
-	if err := os.MkdirAll(ensureDstPath, 0700); err != nil {
-		return err
+	if ensureDstPath != "" {
+		if err := os.MkdirAll(ensureDstPath, 0700); err != nil {
+			return err
+		}
 	}
 	dst = filepath.Clean(dst)
 

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -49,6 +49,33 @@ func TestCopyDirectoryWithLocalSymlink(t *testing.T) {
 	}
 }
 
+func TestCopyToWorkDir(t *testing.T) {
+	t1, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(t1)
+
+	apply := fstest.Apply(
+		fstest.CreateFile("foo.txt", []byte("contents"), 0755),
+	)
+
+	require.NoError(t, apply.Apply(t1))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	t2, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(t2)
+	defer os.Chdir(wd)
+	os.Chdir(t2)
+
+	err = Copy(context.TODO(), filepath.Join(t1, "foo.txt"), "foo.txt")
+	require.NoError(t, err)
+
+	err = fstest.CheckDirectoryEqual(t1, t2)
+	require.NoError(t, err)
+}
+
 func TestCopySingleFile(t *testing.T) {
 	t1, err := ioutil.TempDir("", "test")
 	require.NoError(t, err)


### PR DESCRIPTION

Signed-off-by: Tibor Vass <tibor@docker.com>