### PR TITLE
receive: convert file path to local form when registering.

### DIFF
--- a/diskwriter.go
+++ b/diskwriter.go
@@ -80,9 +80,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 		}
 	}()
 
-	p = filepath.FromSlash(p)
-
-	destPath := filepath.Join(dw.dest, p)
+	destPath := filepath.Join(dw.dest, filepath.FromSlash(p))
 
 	if kind == ChangeKindDelete {
 		// todo: no need to validate if diff is trusted but is it always?

--- a/receive.go
+++ b/receive.go
@@ -3,6 +3,7 @@ package fsutil
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -169,7 +170,7 @@ func (r *receiver) run(ctx context.Context) error {
 				}
 				if fileCanRequestData(os.FileMode(p.Stat.Mode)) {
 					r.mu.Lock()
-					r.files[p.Stat.Path] = i
+					r.files[filepath.FromSlash(p.Stat.Path)] = i
 					r.mu.Unlock()
 				}
 				i++

--- a/receive.go
+++ b/receive.go
@@ -3,7 +3,6 @@ package fsutil
 import (
 	"io"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -170,7 +169,7 @@ func (r *receiver) run(ctx context.Context) error {
 				}
 				if fileCanRequestData(os.FileMode(p.Stat.Mode)) {
 					r.mu.Lock()
-					r.files[filepath.FromSlash(p.Stat.Path)] = i
+					r.files[p.Stat.Path] = i
 					r.mu.Unlock()
 				}
 				i++


### PR DESCRIPTION
This matches the same transformation as is done in `DiskWriter.Handle`, which
eventually gets passed to the `AsyncDataCb` AKA `receiver.asyncDataFunc` which
performs the lookup.

This matters on Windows where `filepath.FromSlash` will convert `/` into `\`.
I've tested this (in the context of buildkit) with a Linux `sender` and Windows
`receiver`, I've no capability to test the opposite direction.

Signed-off-by: Ian Campbell <ijc@docker.com>