### PR TITLE
Fixes for non-root/symlink copy tests

### DIFF
--- a/chtimes_nolinux.go
+++ b/chtimes_nolinux.go
@@ -9,5 +9,12 @@ import (
 
 func chtimes(path string, un int64) error {
 	mtime := time.Unix(0, un)
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
 	return os.Chtimes(path, mtime, mtime)
 }

--- a/diskwriter.go
+++ b/diskwriter.go
@@ -102,8 +102,10 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 		return errors.Errorf("%s invalid change without stat information", p)
 	}
 
+	statCopy := *stat
+
 	if dw.filter != nil {
-		if ok := dw.filter(stat); !ok {
+		if ok := dw.filter(&statCopy); !ok {
 			return nil
 		}
 	}
@@ -122,7 +124,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 	}
 
 	if oldFi != nil && fi.IsDir() && oldFi.IsDir() {
-		if err := rewriteMetadata(destPath, stat); err != nil {
+		if err := rewriteMetadata(destPath, &statCopy); err != nil {
 			return errors.Wrapf(err, "error setting dir metadata for %s", destPath)
 		}
 		return nil
@@ -141,16 +143,16 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 			return errors.Wrapf(err, "failed to create dir %s", newPath)
 		}
 	case fi.Mode()&os.ModeDevice != 0 || fi.Mode()&os.ModeNamedPipe != 0:
-		if err := handleTarTypeBlockCharFifo(newPath, stat); err != nil {
+		if err := handleTarTypeBlockCharFifo(newPath, &statCopy); err != nil {
 			return errors.Wrapf(err, "failed to create device %s", newPath)
 		}
 	case fi.Mode()&os.ModeSymlink != 0:
-		if err := os.Symlink(stat.Linkname, newPath); err != nil {
+		if err := os.Symlink(statCopy.Linkname, newPath); err != nil {
 			return errors.Wrapf(err, "failed to symlink %s", newPath)
 		}
-	case stat.Linkname != "":
-		if err := os.Link(filepath.Join(dw.dest, stat.Linkname), newPath); err != nil {
-			return errors.Wrapf(err, "failed to link %s to %s", newPath, stat.Linkname)
+	case statCopy.Linkname != "":
+		if err := os.Link(filepath.Join(dw.dest, statCopy.Linkname), newPath); err != nil {
+			return errors.Wrapf(err, "failed to link %s to %s", newPath, statCopy.Linkname)
 		}
 	default:
 		isRegularFile = true
@@ -170,7 +172,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 		}
 	}
 
-	if err := rewriteMetadata(newPath, stat); err != nil {
+	if err := rewriteMetadata(newPath, &statCopy); err != nil {
 		return errors.Wrapf(err, "error setting metadata for %s", newPath)
 	}
 

--- a/walker.go
+++ b/walker.go
@@ -131,13 +131,13 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 		stat := &Stat{
 			Path:    path,
 			Mode:    uint32(fi.Mode()),
-			Size_:   fi.Size(),
 			ModTime: fi.ModTime().UnixNano(),
 		}
 
 		setUnixOpt(fi, stat, path, seenFiles)
 
 		if !fi.IsDir() {
+			stat.Size_ = fi.Size()
 			if fi.Mode()&os.ModeSymlink != 0 {
 				link, err := os.Readlink(origpath)
 				if err != nil {


### PR DESCRIPTION
fixes #26 

@thaJeztah Thanks for bringing my attention to this.

There are some fixes in here that are mostly just for making the test compatible with non-linux and non-root user, but two cases also need to be checked when vendoring this to buildkit. These are:

- handling the size on directory records (now resets to 0)
- handling mode of symlinks. This is tricky because it is only supported on linux (and even then with some crazy hacks). I think we need to detect it in buildkit hash function as well and force set.

This also fixes the chtimes issue that showed up on darwin. I'm not sure why this one was not failing for anyone else.