### PR TITLE
Minor cleanups in tests and imports

### DIFF
--- a/bench/util.go
+++ b/bench/util.go
@@ -6,12 +6,11 @@ import (
 	"errors"
 	"io/ioutil"
 	"math"
+	mathrand "math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
-
-	mathrand "math/rand"
 )
 
 func createTestDir(n int) (string, error) {

--- a/cmd/walk/walk.go
+++ b/cmd/walk/walk.go
@@ -16,7 +16,7 @@ func main() {
 		panic("source path not set")
 	}
 
-	excludes := []string{}
+	var excludes []string
 
 	if len(flag.Args()) > 1 {
 		dt, err := ioutil.ReadFile(flag.Args()[1])

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -2,12 +2,11 @@ package fs
 
 import (
 	"context"
+	_ "crypto/sha256"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
-
-	_ "crypto/sha256"
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"

--- a/diskwriter_test.go
+++ b/diskwriter_test.go
@@ -17,8 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// RequiresRoot skips tests that require root
-func RequiresRoot(t *testing.T) {
+// requiresRoot skips tests that require root
+func requiresRoot(t *testing.T) {
+	t.Helper()
 	if os.Getuid() != 0 {
 		t.Skip("skipping test that requires root")
 		return
@@ -26,7 +27,7 @@ func RequiresRoot(t *testing.T) {
 }
 
 func TestWriterSimple(t *testing.T) {
-	RequiresRoot(t)
+	requiresRoot(t)
 
 	changes := changeStream([]string{
 		"ADD bar dir",
@@ -164,7 +165,7 @@ func readAsAdd(f HandleChangeFn) filepath.WalkFunc {
 	}
 }
 
-func noOpWriteTo(context.Context, string, io.WriteCloser) error {
+func noOpWriteTo(_ context.Context, _ string, _ io.WriteCloser) error {
 	return nil
 }
 
@@ -211,7 +212,7 @@ func (nb *notificationBuffer) HandleChange(kind ChangeKind, p string, fi os.File
 	} else {
 		h, ok := fi.(hashed)
 		if !ok {
-			return errors.Errorf("invalid fileinfo: %p", p)
+			return errors.Errorf("invalid FileInfo: %p", p)
 		}
 		nb.items[p] = h.Digest()
 	}
@@ -223,12 +224,4 @@ func (nb *notificationBuffer) Hash(p string) (digest.Digest, bool) {
 	v, ok := nb.items[p]
 	nb.Unlock()
 	return v, ok
-}
-
-type fileInfo struct {
-	digest digest.Digest
-}
-
-func (fi *fileInfo) Digest() digest.Digest {
-	return fi.digest
 }


### PR DESCRIPTION
- Marked `RequiresRoot` as helper, so that line-numbers match in output, and unexported it
- Removed the `fileInfo` type, as it was no longer used since https://github.com/tonistiigi/fsutil/commit/195d62bee906e45aa700b8ebeb3417f7b126bb23 (https://github.com/tonistiigi/fsutil/pull/7)
