### PR TITLE
Allow followed symlinks on walker

### DIFF
--- a/followlinks.go
+++ b/followlinks.go
@@ -1,0 +1,150 @@
+package fsutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	strings "strings"
+
+	"github.com/pkg/errors"
+)
+
+func FollowLinks(root string, paths []string) ([]string, error) {
+	r := &symlinkResolver{root: root, resolved: map[string]struct{}{}}
+	for _, p := range paths {
+		if err := r.append(p); err != nil {
+			return nil, err
+		}
+	}
+	res := make([]string, 0, len(r.resolved))
+	for r := range r.resolved {
+		res = append(res, r)
+	}
+	sort.Strings(res)
+	return dedupePaths(res), nil
+}
+
+type symlinkResolver struct {
+	root     string
+	resolved map[string]struct{}
+}
+
+func (r *symlinkResolver) append(p string) error {
+	p = filepath.Join(".", p)
+	current := "."
+	for {
+		parts := strings.SplitN(p, string(filepath.Separator), 2)
+		current = filepath.Join(current, parts[0])
+
+		targets, err := r.readSymlink(current, true)
+		if err != nil {
+			return err
+		}
+
+		p = ""
+		if len(parts) == 2 {
+			p = parts[1]
+		}
+
+		if p == "" || targets != nil {
+			if _, ok := r.resolved[current]; ok {
+				return nil
+			}
+		}
+
+		if targets != nil {
+			r.resolved[current] = struct{}{}
+			for _, target := range targets {
+				if err := r.append(filepath.Join(target, p)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		if p == "" {
+			r.resolved[current] = struct{}{}
+			return nil
+		}
+	}
+}
+
+func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, error) {
+	realPath := filepath.Join(r.root, p)
+	base := filepath.Base(p)
+	if allowWildcard && containsWildcards(base) {
+		fis, err := ioutil.ReadDir(filepath.Dir(realPath))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, errors.Wrapf(err, "failed to read dir %s", filepath.Dir(realPath))
+		}
+		var out []string
+		for _, f := range fis {
+			if ok, _ := filepath.Match(base, f.Name()); ok {
+				res, err := r.readSymlink(filepath.Join(filepath.Dir(p), f.Name()), false)
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, res...)
+			}
+		}
+		return out, nil
+	}
+
+	fi, err := os.Lstat(realPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "failed to lstat %s", realPath)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return nil, nil
+	}
+	link, err := os.Readlink(realPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to readlink %s", realPath)
+	}
+	link = filepath.Clean(link)
+	if filepath.IsAbs(link) {
+		return []string{link}, nil
+	}
+	return []string{
+		filepath.Join(string(filepath.Separator), filepath.Join(filepath.Dir(p), link)),
+	}, nil
+}
+
+func containsWildcards(name string) bool {
+	isWindows := runtime.GOOS == "windows"
+	for i := 0; i < len(name); i++ {
+		ch := name[i]
+		if ch == '\\' && !isWindows {
+			i++
+		} else if ch == '*' || ch == '?' || ch == '[' {
+			return true
+		}
+	}
+	return false
+}
+
+// dedupePaths expects input as a sorted list
+func dedupePaths(in []string) []string {
+	out := make([]string, 0, len(in))
+	var last string
+	for _, s := range in {
+		// if one of the paths is root there is no filter
+		if s == "." {
+			return nil
+		}
+		if strings.HasPrefix(s, last+string(filepath.Separator)) {
+			continue
+		}
+		out = append(out, s)
+		last = s
+	}
+	return out
+}

--- a/followlinks_test.go
+++ b/followlinks_test.go
@@ -1,0 +1,175 @@
+package fsutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowLinks(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/foo", []byte("contents"), 0600),
+		fstest.Symlink("foo", "dir/l1"),
+		fstest.Symlink("dir/l1", "l2"),
+		fstest.CreateFile("bar", nil, 0600),
+		fstest.CreateFile("baz", nil, 0600),
+	)
+
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err := FollowLinks(tmpDir, []string{"l2", "bar"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"bar", "dir/foo", "dir/l1", "l2"})
+}
+
+func TestFollowLinksLoop(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apply := fstest.Apply(
+		fstest.Symlink("l1", "l1"),
+		fstest.Symlink("l2", "l3"),
+		fstest.Symlink("l3", "l2"),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err := FollowLinks(tmpDir, []string{"l1", "l3"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"l1", "l2", "l3"})
+}
+
+func TestFollowLinksAbsolute(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.Symlink("/foo/bar/baz", "dir/l1"),
+		fstest.CreateDir("foo", 0700),
+		fstest.Symlink("../", "foo/bar"),
+		fstest.CreateFile("baz", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err := FollowLinks(tmpDir, []string{"dir/l1"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"baz", "dir/l1", "foo/bar"})
+
+	// same but a link outside root
+	tmpDir, err = ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apply = fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.Symlink("/foo/bar/baz", "dir/l1"),
+		fstest.CreateDir("foo", 0700),
+		fstest.Symlink("../../../", "foo/bar"),
+		fstest.CreateFile("baz", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err = FollowLinks(tmpDir, []string{"dir/l1"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"baz", "dir/l1", "foo/bar"})
+}
+
+func TestFollowLinksNotExists(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	out, err := FollowLinks(tmpDir, []string{"foo/bar/baz", "bar/baz"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"bar/baz", "foo/bar/baz"})
+
+	// root works fine with empty directory
+	out, err = FollowLinks(tmpDir, []string{"."})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string(nil))
+
+	out, err = FollowLinks(tmpDir, []string{"f*/foo/t*"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"f*/foo/t*"})
+}
+
+func TestFollowLinksNormalized(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	out, err := FollowLinks(tmpDir, []string{"foo/bar/baz", "foo/bar"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"foo/bar"})
+
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.Symlink("/foo", "dir/l1"),
+		fstest.Symlink("/", "dir/l2"),
+		fstest.CreateDir("foo", 0700),
+		fstest.CreateFile("foo/bar", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err = FollowLinks(tmpDir, []string{"dir/l1", "foo/bar"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"dir/l1", "foo"})
+
+	out, err = FollowLinks(tmpDir, []string{"dir/l2", "foo", "foo/bar"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string(nil))
+}
+
+func TestFollowLinksWildcard(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateDir("foo", 0700),
+		fstest.Symlink("/foo/bar1", "dir/l1"),
+		fstest.Symlink("/foo/bar2", "dir/l2"),
+		fstest.Symlink("/foo/bar3", "dir/anotherlink"),
+		fstest.Symlink("../baz", "foo/bar2"),
+		fstest.CreateFile("foo/bar1", nil, 0600),
+		fstest.CreateFile("foo/bar3", nil, 0600),
+		fstest.CreateFile("baz", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	out, err := FollowLinks(tmpDir, []string{"dir/l*"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"baz", "dir/l*", "foo/bar1", "foo/bar2"})
+
+	out, err = FollowLinks(tmpDir, []string{"dir"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"dir"})
+
+	out, err = FollowLinks(tmpDir, []string{"dir", "dir/*link"})
+	require.NoError(t, err)
+
+	require.Equal(t, out, []string{"dir", "foo/bar3"})
+}

--- a/walker.go
+++ b/walker.go
@@ -40,7 +40,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	}
 
 	var lastIncludedDir string
-	var includePatternPrefixes []string
+	var includePatterns []string
 
 	seenFiles := make(map[uint64]string)
 	return filepath.Walk(root, func(path string, fi os.FileInfo, err error) (retErr error) {
@@ -67,33 +67,36 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 		if opt != nil {
 			if opt.IncludePatterns != nil {
-				if includePatternPrefixes == nil {
-					includePatternPrefixes = patternPrefixes(opt.IncludePatterns)
+				if includePatterns == nil {
+					includePatterns = make([]string, len(opt.IncludePatterns))
+					for k := range opt.IncludePatterns {
+						includePatterns[k] = filepath.Clean(opt.IncludePatterns[k])
+					}
 				}
-				matched := false
+				skip := false
 				if lastIncludedDir != "" {
 					if strings.HasPrefix(path, lastIncludedDir+string(filepath.Separator)) {
-						matched = true
+						skip = true
 					}
 				}
-				if !matched {
-					for _, p := range opt.IncludePatterns {
-						if m, _ := filepath.Match(p, path); m {
+
+				if !skip {
+					matched := false
+					partial := true
+					for _, p := range includePatterns {
+						if ok, p := matchPrefix(p, path); ok {
 							matched = true
-							break
+							if !p {
+								partial = false
+								break
+							}
 						}
 					}
-					if matched && fi.IsDir() {
-						lastIncludedDir = path
-					}
-				}
-				if !matched {
-					if !fi.IsDir() {
+					if !matched {
 						return nil
-					} else {
-						if noPossiblePrefixMatch(path, includePatternPrefixes) {
-							return filepath.SkipDir
-						}
+					}
+					if !partial && fi.IsDir() {
+						lastIncludedDir = path
 					}
 				}
 			}
@@ -199,29 +202,28 @@ func (s *StatInfo) Sys() interface{} {
 	return s.Stat
 }
 
-func patternPrefixes(patterns []string) []string {
-	pfxs := make([]string, 0, len(patterns))
-	for _, ptrn := range patterns {
-		idx := strings.IndexFunc(ptrn, func(ch rune) bool {
-			return ch == '*' || ch == '?' || ch == '[' || ch == '\\'
-		})
-		if idx == -1 {
-			idx = len(ptrn)
-		}
-		pfxs = append(pfxs, ptrn[:idx])
+func matchPrefix(pattern, name string) (bool, bool) {
+	count := strings.Count(name, string(filepath.Separator))
+	partial := false
+	if strings.Count(pattern, string(filepath.Separator)) > count {
+		pattern = trimUntilIndex(pattern, string(filepath.Separator), count)
+		partial = true
 	}
-	return pfxs
+	m, _ := filepath.Match(pattern, name)
+	return m, partial
 }
 
-func noPossiblePrefixMatch(p string, pfxs []string) bool {
-	for _, pfx := range pfxs {
-		chk := p
-		if len(pfx) < len(p) {
-			chk = p[:len(pfx)]
-		}
-		if strings.HasPrefix(pfx, chk) {
-			return false
+func trimUntilIndex(str, sep string, count int) string {
+	s := str
+	i := 0
+	c := 0
+	for {
+		idx := strings.Index(s, sep)
+		s = s[idx+len(sep):]
+		i += idx + len(sep)
+		c++
+		if c >= count {
+			return str[:i-len(sep)]
 		}
 	}
-	return true
 }

--- a/walker_test.go
+++ b/walker_test.go
@@ -150,6 +150,61 @@ file foo/bar2
 
 }
 
+func TestWalkerFollowLinks(t *testing.T) {
+	d, err := tmpDir(changeStream([]string{
+		"ADD bar file",
+		"ADD foo dir",
+		"ADD foo/l1 symlink /baz/one",
+		"ADD foo/l2 symlink /baz/two",
+		"ADD baz dir",
+		"ADD baz/one file",
+		"ADD baz/two symlink ../bax",
+		"ADD bax file",
+		"ADD bay file", // not included
+	}))
+	assert.NoError(t, err)
+	defer os.RemoveAll(d)
+	b := &bytes.Buffer{}
+	err = Walk(context.Background(), d, &WalkOpt{
+		FollowPaths: []string{"foo/l*", "bar"},
+	}, bufWalk(b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, `file bar
+file bax
+dir baz
+file baz/one
+symlink:../bax baz/two
+dir foo
+symlink:/baz/one foo/l1
+symlink:/baz/two foo/l2
+`, string(b.Bytes()))
+}
+
+func TestWalkerFollowLinksToRoot(t *testing.T) {
+	d, err := tmpDir(changeStream([]string{
+		"ADD foo symlink .",
+		"ADD bar file",
+		"ADD bax file",
+		"ADD bay dir",
+		"ADD bay/baz file",
+	}))
+	assert.NoError(t, err)
+	defer os.RemoveAll(d)
+	b := &bytes.Buffer{}
+	err = Walk(context.Background(), d, &WalkOpt{
+		FollowPaths: []string{"foo"},
+	}, bufWalk(b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, `file bar
+file bax
+dir bay
+file bay/baz
+symlink:. foo
+`, string(b.Bytes()))
+}
+
 func TestWalkerMap(t *testing.T) {
 	d, err := tmpDir(changeStream([]string{
 		"ADD bar file",

--- a/walker_test.go
+++ b/walker_test.go
@@ -96,6 +96,36 @@ file bar/foo
 
 	assert.Equal(t, `file foo2
 `, string(b.Bytes()))
+
+	b.Reset()
+	err = Walk(context.Background(), d, &WalkOpt{
+		IncludePatterns: []string{"b*/f*"},
+	}, bufWalk(b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, `dir bar
+file bar/foo
+`, string(b.Bytes()))
+
+	b.Reset()
+	err = Walk(context.Background(), d, &WalkOpt{
+		IncludePatterns: []string{"b*/foo"},
+	}, bufWalk(b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, `dir bar
+file bar/foo
+`, string(b.Bytes()))
+
+	b.Reset()
+	err = Walk(context.Background(), d, &WalkOpt{
+		IncludePatterns: []string{"b*/"},
+	}, bufWalk(b))
+	assert.NoError(t, err)
+
+	assert.Equal(t, `dir bar
+file bar/foo
+`, string(b.Bytes()))
 }
 
 func TestWalkerExclude(t *testing.T) {


### PR DESCRIPTION
This allows setting paths on a walker that are evaluated as symlinks and the target paths on these paths are added to the includepatterns.

This enables fixing the cases where a Dockerfile context detection can make sure that if the source path that user requested is a symlink, the target path is included in the context as well.