### PR TITLE
Allow dynamic subdir wrapper for send

### DIFF
--- a/bench/diffcopy.go
+++ b/bench/diffcopy.go
@@ -20,7 +20,7 @@ func diffCopy(proto bool, src, dest string) error {
 	}
 
 	eg.Go(func() error {
-		return fsutil.Send(ctx, s1, src, nil, nil)
+		return fsutil.Send(ctx, s1, fsutil.NewFS(src, nil), nil)
 	})
 	eg.Go(func() error {
 		return fsutil.Receive(ctx, s2, dest, fsutil.ReceiveOpt{})

--- a/cmd/send/send.go
+++ b/cmd/send/send.go
@@ -18,7 +18,7 @@ func main() {
 	ctx := context.Background()
 	s := util.NewProtoStream(ctx, os.Stdin, os.Stdout)
 
-	if err := fsutil.Send(ctx, s, flag.Args()[0], nil, nil); err != nil {
+	if err := fsutil.Send(ctx, s, fsutil.NewFS(flag.Args()[0], nil), nil); err != nil {
 		panic(err)
 	}
 }

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,33 @@
+package fsutil
+
+import (
+	"context"
+	io "io"
+	"os"
+	"path/filepath"
+)
+
+type FS interface {
+	Walk(context.Context, filepath.WalkFunc) error
+	Open(string) (io.ReadCloser, error)
+}
+
+func NewFS(root string, opt *WalkOpt) FS {
+	return &fs{
+		root: root,
+		opt:  opt,
+	}
+}
+
+type fs struct {
+	root string
+	opt  *WalkOpt
+}
+
+func (fs *fs) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+	return Walk(ctx, fs.root, fs.opt, fn)
+}
+
+func (fs *fs) Open(p string) (io.ReadCloser, error) {
+	return os.Open(filepath.Join(fs.root, p))
+}

--- a/fs.go
+++ b/fs.go
@@ -2,9 +2,13 @@ package fsutil
 
 import (
 	"context"
-	io "io"
+	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type FS interface {
@@ -30,4 +34,38 @@ func (fs *fs) Walk(ctx context.Context, fn filepath.WalkFunc) error {
 
 func (fs *fs) Open(p string) (io.ReadCloser, error) {
 	return os.Open(filepath.Join(fs.root, p))
+}
+
+func SubDirFS(fs FS, stat Stat) FS {
+	return &subDirFS{fs: fs, stat: stat}
+}
+
+type subDirFS struct {
+	fs   FS
+	stat Stat
+}
+
+func (fs *subDirFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+	main := &StatInfo{Stat: &fs.stat}
+	if !main.IsDir() {
+		return errors.Errorf("fs subdir not mode directory")
+	}
+	if main.Name() != fs.stat.Path {
+		return errors.Errorf("subdir path must be single file")
+	}
+	if err := fn(fs.stat.Path, main, nil); err != nil {
+		return err
+	}
+	return fs.fs.Walk(ctx, func(p string, fi os.FileInfo, err error) error {
+		stat, ok := fi.Sys().(*Stat)
+		if !ok {
+			return errors.Wrapf(err, "invalid fileinfo without stat info: %s", p)
+		}
+		stat.Path = path.Join(fs.stat.Path, stat.Path)
+		return fn(filepath.Join(fs.stat.Path, p), &StatInfo{stat}, nil)
+	})
+}
+
+func (fs *subDirFS) Open(p string) (io.ReadCloser, error) {
+	return fs.fs.Open(strings.TrimPrefix(p, fs.stat.Path+"/"))
 }

--- a/receive_test.go
+++ b/receive_test.go
@@ -38,7 +38,7 @@ func TestInvalidExcludePatterns(t *testing.T) {
 
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
-		return Send(ctx, s1, d, &WalkOpt{ExcludePatterns: []string{"!"}}, nil)
+		return Send(ctx, s1, NewFS(d, &WalkOpt{ExcludePatterns: []string{"!"}}), nil)
 	})
 	eg.Go(func() error {
 		return Receive(ctx, s2, dest, ReceiveOpt{
@@ -85,13 +85,13 @@ func TestCopySimple(t *testing.T) {
 
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
-		return Send(ctx, s1, d, &WalkOpt{
+		return Send(ctx, s1, NewFS(d, &WalkOpt{
 			Map: func(s *Stat) bool {
 				s.Uid = 0
 				s.Gid = 0
 				return true
 			},
-		}, nil)
+		}), nil)
 	})
 	eg.Go(func() error {
 		return Receive(ctx, s2, dest, ReceiveOpt{
@@ -158,13 +158,13 @@ file zzz.aa
 
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
-		return Send(ctx, s1, d, &WalkOpt{
+		return Send(ctx, s1, NewFS(d, &WalkOpt{
 			Map: func(s *Stat) bool {
 				s.Uid = 0
 				s.Gid = 0
 				return true
 			},
-		}, nil)
+		}), nil)
 	})
 	eg.Go(func() error {
 		return Receive(ctx, s2, dest, ReceiveOpt{

--- a/send.go
+++ b/send.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -23,11 +22,10 @@ type Stream interface {
 	Context() context.Context
 }
 
-func Send(ctx context.Context, conn Stream, root string, opt *WalkOpt, progressCb func(int, bool)) error {
+func Send(ctx context.Context, conn Stream, fs FS, progressCb func(int, bool)) error {
 	s := &sender{
 		conn:         &syncStream{Stream: conn},
-		root:         root,
-		opt:          opt,
+		fs:           fs,
 		files:        make(map[uint32]string),
 		progressCb:   progressCb,
 		sendpipeline: make(chan *sendHandle, 128),
@@ -42,8 +40,7 @@ type sendHandle struct {
 
 type sender struct {
 	conn            Stream
-	opt             *WalkOpt
-	root            string
+	fs              FS
 	files           map[uint32]string
 	mu              sync.RWMutex
 	progressCb      func(int, bool)
@@ -130,7 +127,7 @@ func (s *sender) queue(id uint32) error {
 }
 
 func (s *sender) sendFile(h *sendHandle) error {
-	f, err := os.Open(filepath.Join(s.root, h.path))
+	f, err := s.fs.Open(h.path)
 	if err == nil {
 		defer f.Close()
 		buf := bufPool.Get().([]byte)
@@ -144,7 +141,7 @@ func (s *sender) sendFile(h *sendHandle) error {
 
 func (s *sender) walk(ctx context.Context) error {
 	var i uint32 = 0
-	err := Walk(ctx, s.root, s.opt, func(path string, fi os.FileInfo, err error) error {
+	err := s.fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This changes the input of send from strict walker options for a more generic `FS` interface.

The second commit uses the `FS` interface to allow wrapping the sent files to a dynamic subdirectory.

@tiborvass 