### PR TITLE
fix copy_file_range on s390x

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -61,7 +61,7 @@ func copyFileContent(dst, src *os.File) error {
 
 		n, err := unix.CopyFileRange(int(src.Fd()), nil, int(dst.Fd()), nil, desired, 0)
 		if err != nil {
-			if (err != unix.ENOSYS && err != unix.EXDEV) || !first {
+			if (err != unix.ENOSYS && err != unix.EXDEV && err != unix.EPERM) || !first {
 				return errors.Wrap(err, "copy file range failed")
 			}
 


### PR DESCRIPTION
In `s390x` if run in limited caps `copy_file_range` returns `EPERM` instead of `ENOSYS` causing the copy to fail. Add a workaround to ignore `EPERM` as well that should be safe as no other case should return it. Have reported this to continuity where this code originated.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>