### PR TITLE
copy: updates for buildkit fileop

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -8,7 +8,9 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 )
 
@@ -19,9 +21,46 @@ var bufferPool = &sync.Pool{
 	},
 }
 
+func ResolveWildcards(root, src string) ([]string, error) {
+	d1, d2 := splitWildcards(src)
+	if d2 != "" {
+		matches, err := resolveWildcards(filepath.Join(root, d1), d2)
+		if err != nil {
+			return nil, err
+		}
+		for i, m := range matches {
+			p, err := rel(root, m)
+			if err != nil {
+				return nil, err
+			}
+			p, err = fs.RootPath(root, p)
+			if err != nil {
+				return nil, err
+			}
+			p, err = rel(root, p)
+			if err != nil {
+				return nil, err
+			}
+			matches[i] = p
+		}
+		return matches, nil
+	}
+
+	p, err := fs.RootPath(root, d1)
+	if err != nil {
+		return nil, err
+	}
+	p, err = rel(root, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{p}, nil
+}
+
 // Copy copies files using `cp -a` semantics.
 // Copy is likely unsafe to be used in non-containerized environments.
-func Copy(ctx context.Context, src, dst string, opts ...Opt) error {
+func Copy(ctx context.Context, srcRoot, src, dstRoot, dst string, opts ...Opt) error {
 	var ci CopyInfo
 	for _, o := range opts {
 		o(&ci)
@@ -31,38 +70,41 @@ func Copy(ctx context.Context, src, dst string, opts ...Opt) error {
 		ensureDstPath = d
 	}
 	if ensureDstPath != "" {
-		if err := mkdirp(ensureDstPath, ci); err != nil {
+		ensureDstPath, err := fs.RootPath(dstRoot, ensureDstPath)
+		if err != nil {
+			return err
+		}
+		if err := MkdirAll(ensureDstPath, 0755, ci.Chown, ci.Utime); err != nil {
 			return err
 		}
 	}
-	dst = filepath.Clean(dst)
 
-	c := newCopier(ci.Chown, ci.XAttrErrorHandler)
+	dst, err := fs.RootPath(dstRoot, filepath.Clean(dst))
+	if err != nil {
+		return err
+	}
+
+	c := newCopier(ci.Chown, ci.Utime, ci.Mode, ci.XAttrErrorHandler)
 	srcs := []string{src}
 
-	destRequiresDir := false
 	if ci.AllowWildcards {
-		d1, d2 := splitWildcards(src)
-		if d2 != "" {
-			matches, err := resolveWildcards(d1, d2)
-			if err != nil {
-				return err
-			}
-			srcs = matches
-			destRequiresDir = true
+		matches, err := ResolveWildcards(srcRoot, src)
+		if err != nil {
+			return err
 		}
+		if len(matches) == 0 {
+			return errors.Errorf("no matches found: %s", src)
+		}
+		srcs = matches
 	}
 
 	for _, src := range srcs {
-		srcFollowed, err := filepath.EvalSymlinks(src)
+		srcFollowed, err := fs.RootPath(srcRoot, src)
 		if err != nil {
 			return err
 		}
-		dst, err := normalizedCopyInputs(srcFollowed, src, dst, destRequiresDir)
+		dst, err := c.prepareTargetDir(srcFollowed, src, dst, ci.CopyDirContents)
 		if err != nil {
-			return err
-		}
-		if err := mkdirp(filepath.Dir(dst), ci); err != nil {
 			return err
 		}
 		if err := c.copy(ctx, srcFollowed, dst, false); err != nil {
@@ -73,7 +115,7 @@ func Copy(ctx context.Context, src, dst string, opts ...Opt) error {
 	return nil
 }
 
-func normalizedCopyInputs(srcFollowed, src, destPath string, forceDir bool) (string, error) {
+func (c *copier) prepareTargetDir(srcFollowed, src, destPath string, copyDirContents bool) (string, error) {
 	fiSrc, err := os.Lstat(srcFollowed)
 	if err != nil {
 		return "", err
@@ -86,8 +128,17 @@ func normalizedCopyInputs(srcFollowed, src, destPath string, forceDir bool) (str
 		}
 	}
 
-	if (forceDir && fiSrc.IsDir()) || (!fiSrc.IsDir() && fiDest != nil && fiDest.IsDir()) {
+	if (!copyDirContents && fiSrc.IsDir() && fiDest != nil) || (!fiSrc.IsDir() && fiDest != nil && fiDest.IsDir()) {
 		destPath = filepath.Join(destPath, filepath.Base(src))
+	}
+
+	target := filepath.Dir(destPath)
+
+	if copyDirContents && fiSrc.IsDir() && fiDest == nil {
+		target = destPath
+	}
+	if err := MkdirAll(target, 0755, c.chown, c.utime); err != nil {
+		return "", err
 	}
 
 	return destPath, nil
@@ -101,11 +152,20 @@ type XAttrErrorHandler func(dst, src, xattrKey string, err error) error
 
 type CopyInfo struct {
 	Chown             *ChownOpt
+	Utime             *time.Time
 	AllowWildcards    bool
+	Mode              *int
 	XAttrErrorHandler XAttrErrorHandler
+	CopyDirContents   bool
 }
 
 type Opt func(*CopyInfo)
+
+func WithCopyInfo(ci CopyInfo) func(*CopyInfo) {
+	return func(c *CopyInfo) {
+		*c = ci
+	}
+}
 
 func WithChown(uid, gid int) Opt {
 	return func(ci *CopyInfo) {
@@ -132,17 +192,19 @@ func AllowXAttrErrors(ci *CopyInfo) {
 
 type copier struct {
 	chown             *ChownOpt
+	utime             *time.Time
+	mode              *int
 	inodes            map[uint64]string
 	xattrErrorHandler XAttrErrorHandler
 }
 
-func newCopier(chown *ChownOpt, xeh XAttrErrorHandler) *copier {
+func newCopier(chown *ChownOpt, tm *time.Time, mode *int, xeh XAttrErrorHandler) *copier {
 	if xeh == nil {
 		xeh = func(dst, src, key string, err error) error {
 			return err
 		}
 	}
-	return &copier{inodes: map[uint64]string{}, chown: chown, xattrErrorHandler: xeh}
+	return &copier{inodes: map[uint64]string{}, chown: chown, utime: tm, xattrErrorHandler: xeh, mode: mode}
 }
 
 // dest is always clean
@@ -337,9 +399,6 @@ func resolveWildcards(basePath, comp string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(out) == 0 {
-		return nil, errors.Errorf("no matches found: %s", filepath.Join(basePath, comp))
-	}
 	return out, nil
 }
 
@@ -358,16 +417,4 @@ func rel(basepath, targpath string) (string, error) {
 		}
 	}
 	return filepath.Rel(basepath, targpath)
-}
-
-func mkdirp(p string, ci CopyInfo) error {
-	if err := os.MkdirAll(p, 0755); err != nil {
-		return err
-	}
-	if chown := ci.Chown; chown != nil {
-		if err := os.Lchown(p, chown.Uid, chown.Gid); err != nil {
-			return errors.Wrapf(err, "failed to chown %s", p)
-		}
-	}
-	return nil
 }

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -12,27 +12,42 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func getUidGid(fi os.FileInfo) (uid, gid int) {
+	st := fi.Sys().(*syscall.Stat_t)
+	return int(st.Uid), int(st.Gid)
+}
+
 func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 	st := fi.Sys().(*syscall.Stat_t)
-	uid, gid := int(st.Uid), int(st.Gid)
-	if c.chown != nil {
-		uid, gid = c.chown.Uid, c.chown.Gid
+	chown := c.chown
+	if chown == nil {
+		uid, gid := getUidGid(fi)
+		chown = &ChownOpt{Uid: uid, Gid: gid}
 	}
-	if err := os.Lchown(name, uid, gid); err != nil {
+	if err := Chown(name, chown); err != nil {
 		return errors.Wrapf(err, "failed to chown %s", name)
 	}
 
+	m := fi.Mode()
+	if c.mode != nil {
+		m = (m & ^os.FileMode(0777)) | os.FileMode(*c.mode&0777)
+	}
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {
-		if err := os.Chmod(name, fi.Mode()); err != nil {
+		if err := os.Chmod(name, m); err != nil {
 			return errors.Wrapf(err, "failed to chmod %s", name)
 		}
 	}
 
-	timespec := []syscall.Timespec{sys.StatAtime(st), sys.StatMtime(st)}
-	if err := syscall.UtimesNano(name, timespec); err != nil {
-		return errors.Wrapf(err, "failed to utime %s", name)
+	if c.utime != nil {
+		if err := Utimes(name, c.utime); err != nil {
+			return err
+		}
+	} else {
+		timespec := []unix.Timespec{unix.Timespec(sys.StatAtime(st)), unix.Timespec(sys.StatMtime(st))}
+		if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return errors.Wrapf(err, "failed to utime %s", name)
+		}
 	}
-
 	return nil
 }
 

--- a/copy/copy_windows.go
+++ b/copy/copy_windows.go
@@ -24,7 +24,7 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	return nil
 }
 

--- a/copy/mkdir.go
+++ b/copy/mkdir.go
@@ -1,0 +1,74 @@
+package fs
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func Chown(p string, user *ChownOpt) error {
+	if user != nil {
+		if err := os.Lchown(p, user.Uid, user.Gid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MkdirAll is forked os.MkdirAll
+func MkdirAll(path string, perm os.FileMode, user *ChownOpt, tm *time.Time) error {
+	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
+	dir, err := os.Stat(path)
+	if err == nil {
+		if dir.IsDir() {
+			return nil
+		}
+		return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+	}
+
+	// Slow path: make sure parent exists and then call Mkdir for path.
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) { // Skip trailing path separator.
+		i--
+	}
+
+	j := i
+	for j > 0 && !os.IsPathSeparator(path[j-1]) { // Scan backward over element.
+		j--
+	}
+
+	if j > 1 {
+		// Create parent.
+		err = MkdirAll(fixRootDirectory(path[:j-1]), perm, user, tm)
+		if err != nil {
+			return err
+		}
+	}
+
+	dir, err1 := os.Lstat(path)
+	if err1 == nil && dir.IsDir() {
+		return nil
+	}
+
+	// Parent now exists; invoke Mkdir and use its result.
+	err = os.Mkdir(path, perm)
+	if err != nil {
+		// Handle arguments like "foo/." by
+		// double-checking that directory doesn't exist.
+		dir, err1 := os.Lstat(path)
+		if err1 == nil && dir.IsDir() {
+			return nil
+		}
+		return err
+	}
+
+	if err := Chown(path, user); err != nil {
+		return err
+	}
+
+	if err := Utimes(path, tm); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/copy/mkdir_unix.go
+++ b/copy/mkdir_unix.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package fs
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func fixRootDirectory(p string) string {
+	return p
+}
+
+func Utimes(p string, tm *time.Time) error {
+	if tm == nil {
+		return nil
+	}
+
+	ts, err := unix.TimeToTimespec(*tm)
+	if err != nil {
+		return err
+	}
+
+	timespec := []unix.Timespec{ts, ts}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, p, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.Wrapf(err, "failed to utime %s", p)
+	}
+
+	return nil
+}

--- a/copy/mkdir_windows.go
+++ b/copy/mkdir_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package fs
+
+import (
+	"os"
+	"time"
+)
+
+func fixRootDirectory(p string) string {
+	if len(p) == len(`\\?\c:`) {
+		if os.IsPathSeparator(p[0]) && os.IsPathSeparator(p[1]) && p[2] == '?' && os.IsPathSeparator(p[3]) && p[5] == ':' {
+			return p + `\`
+		}
+	}
+	return p
+}
+
+func Utimes(p string, tm *time.Time) error {
+	return nil
+}


### PR DESCRIPTION
updates for the copy package required for https://github.com/moby/buildkit/pull/809

Contains fs root protection as the code doesn't need to run in a container anymore, and support for non-followlinks mode. Some of the previous functionality is refactored to exposed more public functions for controlling wildcards and mkdirp.

@AkihiroSuda @tiborvass 