### PR TITLE
receive: fix possible deadlock on error

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -92,7 +92,13 @@ func (w *dynamicWalker) fill(ctx context.Context, pathC chan<- *currentPath) err
 			if !ok {
 				return nil
 			}
-			pathC <- p
+			select {
+			case pathC <- p:
+			case <-ctx.Done():
+				w.err = ctx.Err()
+				close(w.closeCh)
+				return ctx.Err()
+			}
 		case <-ctx.Done():
 			w.err = ctx.Err()
 			close(w.closeCh)


### PR DESCRIPTION
Context canceling was not properly handled in the case the fill already passed first select and could cause a deadlock if the channel buffer was full. Analysis based on https://gist.github.com/cpuguy83/da1d7af5b6a21a3cc10adaf8d7e66d73 trace.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>