### PR TITLE
fix sending more than two hardlinks

### DIFF
--- a/stat_unix.go
+++ b/stat_unix.go
@@ -46,14 +46,18 @@ func setUnixOpt(fi os.FileInfo, stat *types.Stat, path string, seenFiles map[uin
 		}
 
 		ino := s.Ino
+		linked := false
 		if seenFiles != nil {
 			if s.Nlink > 1 {
 				if oldpath, ok := seenFiles[ino]; ok {
 					stat.Linkname = oldpath
 					stat.Size_ = 0
+					linked = true
 				}
 			}
-			seenFiles[ino] = path
+			if !linked {
+				seenFiles[ino] = path
+			}
 		}
 	}
 }


### PR DESCRIPTION
fix for https://github.com/moby/buildkit/issues/877

The issue appeared if there were more than two hardlinks pointing to the same source causing the validation to fail. The change is to always point them on the same file.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>