### PR TITLE
allow checking file path on filters

### DIFF
--- a/receive_test.go
+++ b/receive_test.go
@@ -116,7 +116,7 @@ func TestCopySwitchDirToFile(t *testing.T) {
 		eg.Go(func() error {
 			defer s1.(*fakeConnProto).closeSend()
 			return Send(ctx, s1, NewFS(src, &WalkOpt{
-				Map: func(s *types.Stat) bool {
+				Map: func(_ string, s *types.Stat) bool {
 					s.Uid = 0
 					s.Gid = 0
 					return true
@@ -127,7 +127,7 @@ func TestCopySwitchDirToFile(t *testing.T) {
 			return Receive(ctx, s2, dest, ReceiveOpt{
 				NotifyHashed:  chs.HandleChange,
 				ContentHasher: simpleSHA256Hasher,
-				Filter: func(s *types.Stat) bool {
+				Filter: func(_ string, s *types.Stat) bool {
 					s.Uid = uint32(os.Getuid())
 					s.Gid = uint32(os.Getgid())
 					return true
@@ -185,7 +185,7 @@ func TestCopySimple(t *testing.T) {
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
 		return Send(ctx, s1, NewFS(d, &WalkOpt{
-			Map: func(s *types.Stat) bool {
+			Map: func(_ string, s *types.Stat) bool {
 				s.Uid = 0
 				s.Gid = 0
 				return true
@@ -196,7 +196,7 @@ func TestCopySimple(t *testing.T) {
 		return Receive(ctx, s2, dest, ReceiveOpt{
 			NotifyHashed:  chs.HandleChange,
 			ContentHasher: simpleSHA256Hasher,
-			Filter: func(s *types.Stat) bool {
+			Filter: func(_ string, s *types.Stat) bool {
 				s.Uid = uint32(os.Getuid())
 				s.Gid = uint32(os.Getgid())
 				return true
@@ -258,7 +258,7 @@ file zzz.aa
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
 		return Send(ctx, s1, NewFS(d, &WalkOpt{
-			Map: func(s *types.Stat) bool {
+			Map: func(_ string, s *types.Stat) bool {
 				s.Uid = 0
 				s.Gid = 0
 				return true
@@ -269,7 +269,7 @@ file zzz.aa
 		return Receive(ctx, s2, dest, ReceiveOpt{
 			NotifyHashed:  chs.HandleChange,
 			ContentHasher: simpleSHA256Hasher,
-			Filter: func(s *types.Stat) bool {
+			Filter: func(_ string, s *types.Stat) bool {
 				s.Uid = uint32(os.Getuid())
 				s.Gid = uint32(os.Getgid())
 				return true

--- a/walker.go
+++ b/walker.go
@@ -19,7 +19,7 @@ type WalkOpt struct {
 	// FollowPaths contains symlinks that are resolved into include patterns
 	// before performing the fs walk
 	FollowPaths []string
-	Map         func(*types.Stat) bool
+	Map         FilterFunc
 }
 
 func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) error {
@@ -157,7 +157,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			return ctx.Err()
 		default:
 			if opt != nil && opt.Map != nil {
-				if allowed := opt.Map(stat); !allowed {
+				if allowed := opt.Map(stat.Path, stat); !allowed {
 					return nil
 				}
 			}

--- a/walker_test.go
+++ b/walker_test.go
@@ -217,7 +217,7 @@ func TestWalkerMap(t *testing.T) {
 	defer os.RemoveAll(d)
 	b := &bytes.Buffer{}
 	err = Walk(context.Background(), d, &WalkOpt{
-		Map: func(s *types.Stat) bool {
+		Map: func(_ string, s *types.Stat) bool {
 			if strings.HasPrefix(s.Path, "foo") {
 				s.Path = "_" + s.Path
 				return true


### PR DESCRIPTION
Extends the current filter callback so that filters can also access the file path, not only the fileinfo structure. Enables adding filters for things similar to https://github.com/moby/buildkit/issues/874

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>