### PR TITLE
receive: use filter on receive diff

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
@@ -25,9 +26,14 @@ func GetWalkerFn(root string) walkerFn {
 				return err
 			}
 
+			stat, ok := f.Sys().(*types.Stat)
+			if !ok {
+				return errors.Errorf("%T invalid file without stat information", f.Sys())
+			}
+
 			p := &currentPath{
 				path: path,
-				f:    f,
+				stat: stat,
 			}
 
 			select {

--- a/diff_containerd.go
+++ b/diff_containerd.go
@@ -87,7 +87,15 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 			}
 
 			var f *types.Stat
-			k, p := pathChange(f1, f2)
+			var f2copy *currentPath
+			if f2 != nil {
+				statCopy := *f2.stat
+				if filter != nil {
+					filter(f2.path, &statCopy)
+				}
+				f2copy = &currentPath{path: f2.path, stat: &statCopy}
+			}
+			k, p := pathChange(f1, f2copy)
 			switch k {
 			case ChangeKindAdd:
 				if rmdir != "" {
@@ -108,11 +116,11 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				}
 				f1 = nil
 			case ChangeKindModify:
-				same, err := sameFile(f1, f2)
+				same, err := sameFile(f1, f2copy)
 				if err != nil {
 					return err
 				}
-				if f1.stat.IsDir() && !f2.stat.IsDir() {
+				if f1.stat.IsDir() && !f2copy.stat.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""

--- a/diff_containerd.go
+++ b/diff_containerd.go
@@ -37,12 +37,12 @@ type ChangeFunc func(ChangeKind, string, os.FileInfo, error) error
 
 type currentPath struct {
 	path string
-	f    os.FileInfo
+	stat *types.Stat
 	//	fullPath string
 }
 
 // doubleWalkDiff walks both directories to create a diff
-func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (err error) {
+func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, filter FilterFunc) (err error) {
 	g, ctx := errgroup.WithContext(ctx)
 
 	var (
@@ -86,14 +86,14 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (er
 				continue
 			}
 
-			var f os.FileInfo
+			var f *types.Stat
 			k, p := pathChange(f1, f2)
 			switch k {
 			case ChangeKindAdd:
 				if rmdir != "" {
 					rmdir = ""
 				}
-				f = f2.f
+				f = f2.stat
 				f2 = nil
 			case ChangeKindDelete:
 				// Check if this file is already removed by being
@@ -101,7 +101,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (er
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if rmdir == "" && f1.stat.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
@@ -112,19 +112,19 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn) (er
 				if err != nil {
 					return err
 				}
-				if f1.f.IsDir() && !f2.f.IsDir() {
+				if f1.stat.IsDir() && !f2.stat.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
 				}
-				f = f2.f
+				f = f2.stat
 				f1 = nil
 				f2 = nil
 				if same {
 					continue loop0
 				}
 			}
-			if err := changeFn(k, p, f, nil); err != nil {
+			if err := changeFn(k, p, &StatInfo{f}, nil); err != nil {
 				return err
 			}
 		}
@@ -159,28 +159,17 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 
 func sameFile(f1, f2 *currentPath) (same bool, retErr error) {
 	// If not a directory also check size, modtime, and content
-	if !f1.f.IsDir() {
-		if f1.f.Size() != f2.f.Size() {
+	if !f1.stat.IsDir() {
+		if f1.stat.Size_ != f2.stat.Size_ {
 			return false, nil
 		}
 
-		t1 := f1.f.ModTime()
-		t2 := f2.f.ModTime()
-		if t1.UnixNano() != t2.UnixNano() {
+		if f1.stat.ModTime != f2.stat.ModTime {
 			return false, nil
 		}
 	}
 
-	ls1, ok := f1.f.Sys().(*types.Stat)
-	if !ok {
-		return false, nil
-	}
-	ls2, ok := f2.f.Sys().(*types.Stat)
-	if !ok {
-		return false, nil
-	}
-
-	return compareStat(ls1, ls2)
+	return compareStat(f1.stat, f2.stat)
 }
 
 // compareStat returns whether the stats are equivalent,

--- a/diskwriter.go
+++ b/diskwriter.go
@@ -194,7 +194,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 
 	if isRegularFile {
 		if dw.opt.AsyncDataCb != nil {
-			dw.requestAsyncFileData(p, destPath, fi)
+			dw.requestAsyncFileData(p, destPath, fi, &statCopy)
 		}
 	} else {
 		return dw.processChange(kind, p, fi, nil)
@@ -203,7 +203,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 	return nil
 }
 
-func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo) {
+func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo, st *types.Stat) {
 	// todo: limit worker threads
 	dw.eg.Go(func() error {
 		if err := dw.processChange(ChangeKindAdd, p, fi, &lazyFileWriter{
@@ -211,7 +211,7 @@ func (dw *DiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo) {
 		}); err != nil {
 			return err
 		}
-		return chtimes(dest, fi.ModTime().UnixNano()) // TODO: parent dirs
+		return chtimes(dest, st.ModTime) // TODO: parent dirs
 	})
 }
 

--- a/receive.go
+++ b/receive.go
@@ -133,7 +133,7 @@ func (r *receiver) run(ctx context.Context) error {
 		if !r.merge {
 			destWalker = GetWalkerFn(r.dest)
 		}
-		err := doubleWalkDiff(ctx, dw.HandleChange, destWalker, w.fill)
+		err := doubleWalkDiff(ctx, dw.HandleChange, destWalker, w.fill, r.filter)
 		if err != nil {
 			return err
 		}
@@ -180,11 +180,11 @@ func (r *receiver) run(ctx context.Context) error {
 					r.mu.Unlock()
 				}
 				i++
-				cp := &currentPath{path: p.Stat.Path, f: &StatInfo{p.Stat}}
-				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, cp.f, nil); err != nil {
+				cp := &currentPath{path: p.Stat.Path, stat: p.Stat}
+				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}
-				if err := r.hlValidator.HandleChange(ChangeKindAdd, cp.path, cp.f, nil); err != nil {
+				if err := r.hlValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}
 				if err := w.update(cp); err != nil {

--- a/types/stat.go
+++ b/types/stat.go
@@ -1,0 +1,7 @@
+package types
+
+import "os"
+
+func (s Stat) IsDir() bool {
+	return os.FileMode(s.Mode).IsDir()
+}


### PR DESCRIPTION
Make sure filter is taken into an account when comparing existing files in the receiver. This issue prevents incremental transfers with userns because the metadata on disk is always different than the one being transferred.