### PR TITLE
Create local atime/mtime wrappers for syscall.Stat_t

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/containerd/containerd/sys"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -46,7 +45,7 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 			return err
 		}
 	} else {
-		timespec := []unix.Timespec{unix.Timespec(sys.StatAtime(st)), unix.Timespec(sys.StatMtime(st))}
+		timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
 		if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 			return errors.Wrapf(err, "failed to utime %s", name)
 		}

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/containerd/containerd/sys"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -45,7 +44,7 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 			return err
 		}
 	} else {
-		timespec := []unix.Timespec{unix.Timespec(sys.StatAtime(st)), unix.Timespec(sys.StatMtime(st))}
+		timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
 		if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 			return errors.Wrapf(err, "failed to utime %s", name)
 		}

--- a/copy/stat_bsd.go
+++ b/copy/stat_bsd.go
@@ -1,0 +1,17 @@
+// +build darwin freebsd netbsd openbsd
+
+package fs
+
+import (
+	"syscall"
+)
+
+// Returns the last-accessed time
+func StatAtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Atimespec
+}
+
+// Returns the last-modified time
+func StatMtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Mtimespec
+}

--- a/copy/stat_sysv.go
+++ b/copy/stat_sysv.go
@@ -1,0 +1,17 @@
+// +build dragonfly linux solaris
+
+package fs
+
+import (
+	"syscall"
+)
+
+// Returns the last-accessed time
+func StatAtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Atim
+}
+
+// Returns the last-modified time
+func StatMtime(st *syscall.Stat_t) syscall.Timespec {
+	return st.Mtim
+}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/tonistiigi/fsutil
 
 require (
 	github.com/Microsoft/go-winio v0.4.11 // indirect
-	github.com/Microsoft/hcsshim v0.8.5 // indirect
-	github.com/containerd/containerd v1.2.4
 	github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker v0.0.0-20180531152204-71cd53e4a197

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
-github.com/Microsoft/hcsshim v0.8.5 h1:kg/pore5Yyf4DXQ5nelSqfaYQG54YIdNeFRKJaPnFiM=
-github.com/Microsoft/hcsshim v0.8.5/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
-github.com/containerd/containerd v1.2.4 h1:qN8LCvw+KA5wVCOnHspD/n2K9cJ34+YOs05qBBWhHiw=
-github.com/containerd/containerd v1.2.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352 h1:CdBoaTKPl60tksFVWYc5QnLWwXBcU+XcLiXx8+NcZ9o=
 github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
These wrappers replace the use of the utility functions in `github.com/containerd/containerd/sys`, and work around https://github.com/golang/go/issues/32887.

The implementations were derived from https://golang.org/search?q=Stat_t#Global_pkg/syscall

Hence, `containerd/containerd` is no longer used and can be removed as a dependency, which also removes `Microsoft/hcsshim`.