### PR TITLE
Fix symlink in tarwriter

### DIFF
--- a/tarwriter.go
+++ b/tarwriter.go
@@ -37,7 +37,11 @@ func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 		hdr.Linkname = stat.Linkname
 		if hdr.Linkname != "" {
 			hdr.Size = 0
-			hdr.Typeflag = tar.TypeLink
+			if fi.Mode() & os.ModeSymlink != 0 {
+				hdr.Typeflag = tar.TypeSymlink
+			} else {
+				hdr.Typeflag = tar.TypeLink
+			}
 		}
 
 		if len(stat.Xattrs) > 0 {


### PR DESCRIPTION
The tarwriter treats symlink as hardlinks. This leads to the tar exporter issue [here](https://github.com/moby/buildkit/issues/1411).