### PR TITLE
add doublestar '**' support

### DIFF
--- a/walker.go
+++ b/walker.go
@@ -64,6 +64,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	var lastIncludedDir string
 
 	seenFiles := make(map[uint64]string)
+	seenDirs := make(map[string]struct{})
 	return filepath.Walk(root, func(path string, fi os.FileInfo, err error) (retErr error) {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -86,6 +87,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			return nil
 		}
 
+		partial := false
 		if opt != nil {
 			if includePatterns != nil {
 				skip := false
@@ -97,9 +99,9 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 				if !skip {
 					matched := false
-					partial := true
+					partial = true
 					for _, p := range includePatterns {
-						if ok, p := matchPrefix(p, path); ok {
+						if ok, p := matchPrefix(p, path, fi.IsDir()); ok {
 							matched = true
 							if !p {
 								partial = false
@@ -147,22 +149,77 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 		}
 
 	passedFilter:
-		stat, err := mkstat(origpath, path, fi, seenFiles)
-		if err != nil {
-			return err
+		// don't report partial files yet, we might later if we eventually find a
+		// non-partial file in this path
+		if partial && fi.IsDir() {
+			return nil
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			if opt != nil && opt.Map != nil {
-				if allowed := opt.Map(stat.Path, stat); !allowed {
-					return nil
+		type pathInfo struct {
+			OrigPath string
+			Path     string
+			Info     os.FileInfo
+		}
+
+		// collect any parent path that have not been previously reported
+		// so we can report it first
+		newPaths := []pathInfo{}
+		origDir := filepath.Dir(origpath)
+		if _, ok := seenDirs[origDir]; !ok {
+			relDir, err := filepath.Rel(root, origDir)
+			if err != nil {
+				return err
+			}
+			dirParts := strings.Split(relDir, string(filepath.Separator))
+			for i := 0; i < len(dirParts); i++ {
+				dir := filepath.Join(dirParts[0 : i+1]...)
+				if dir == "." {
+					continue
+				}
+				origDir := filepath.Join(root, dir)
+				if _, ok := seenDirs[origDir]; !ok {
+					fi, err := os.Stat(origDir)
+					if err != nil {
+						return err
+					}
+					newPaths = append(newPaths, pathInfo{
+						OrigPath: origDir,
+						Path:     dir,
+						Info:     fi,
+					})
+					seenDirs[origDir] = struct{}{}
 				}
 			}
-			if err := fn(stat.Path, &StatInfo{stat}, nil); err != nil {
+		}
+		// if we were reporting a directory then track it so
+		// we don't report it again.
+		if fi.IsDir() {
+			seenDirs[origpath] = struct{}{}
+		}
+		newPaths = append(newPaths, pathInfo{
+			OrigPath: origpath,
+			Path:     path,
+			Info:     fi,
+		})
+
+		for _, path := range newPaths {
+			stat, err := mkstat(path.OrigPath, path.Path, path.Info, seenFiles)
+			if err != nil {
 				return err
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				if opt != nil && opt.Map != nil {
+					if allowed := opt.Map(stat.Path, stat); !allowed {
+						return nil
+					}
+				}
+				if err := fn(stat.Path, &StatInfo{stat}, nil); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -192,9 +249,98 @@ func (s *StatInfo) Sys() interface{} {
 	return s.Stat
 }
 
-func matchPrefix(pattern, name string) (bool, bool) {
-	count := strings.Count(name, string(filepath.Separator))
+func matchPrefix(pattern, name string, isDir bool) (bool, bool) {
 	partial := false
+	if strings.Contains(pattern, "**") {
+		// short-circuit for single "**"
+		if pattern == "**" {
+			return true, false
+		}
+		pattParts := strings.Split(pattern, string(filepath.Separator))
+		lastPatt := len(pattParts) - 1
+		fileParts := strings.Split(name, string(filepath.Separator))
+		lastFile := len(fileParts) - 1
+		// simple "stack" to allow for backtracking the cursors if there
+		// is a partial match with doublestar, so that we can check if
+		// there is a better (complete) match by being greedy with
+		// the doublestar matching, ie if we have `**/b*` we want it to
+		// completely match `foo/bar/baz` rather than return partial
+		// match to `foo/bar`
+		stack := [][2]int{{0, 0}}
+		seenAttempt := map[[2]int]struct{}{}
+	backtrack:
+		for sp := 0; sp < len(stack); sp++ {
+			frame := stack[sp]
+			// track cursors from frame, first frame will be 0,0
+			pattCursor, fileCursor := frame[0], frame[1]
+
+			// if we are backtracking we start in doubleGlobbing mode,
+			doubleGlobbing := pattCursor > 0
+			// if doubleStar globbing is trailing then we match
+			// files and dirs, otherwise just dirs
+			allGlobbing := pattCursor == lastPatt
+
+			// we will double loop, with outer loop being the pattern parts
+			// and the inner loop being the file path parts.  We will
+			// keep a cursor to identify where were are at in the pattern
+			// matching.  If both the pattern parts and the file parts are
+			// entirely consumed then  we have a match, otherwise it
+			// might be a partial match
+		pattern:
+			for pattCursor < len(pattParts) && fileCursor < len(fileParts) {
+				pattPart := pattParts[pattCursor]
+				if pattPart == "**" {
+					// advance pattern cursor so we can start looking for
+					// the next pattern, but flag that we are double globbing
+					// so we can consume file parts that don't match the next
+					// pattern.
+					allGlobbing = pattCursor == lastPatt
+					doubleGlobbing = true
+					pattCursor++
+					continue
+				}
+				for fileCursor < len(fileParts) {
+					if _, ok := seenAttempt[[2]int{pattCursor, fileCursor}]; ok {
+						// been here before, so give up and try next backtrack
+						continue backtrack
+					}
+					seenAttempt[[2]int{pattCursor, fileCursor}] = struct{}{}
+					filePart := fileParts[fileCursor]
+					if ok, _ := filepath.Match(pattPart, filePart); ok {
+						if doubleGlobbing {
+							// we are double globbing, so push on alternate to stack
+							// in case we can get a better complete match being greedy
+							stack = append(stack, [2]int{pattCursor, fileCursor + 1})
+						}
+						partial = true
+						pattCursor++
+						fileCursor++
+						continue pattern
+					}
+					// not a pattern match but it might be captured by double glob.
+					// If target is a file only capture filename if matching
+					// with an allGlobbing pattern (ie `**` will match, `**/...` will not`)
+					if doubleGlobbing && (allGlobbing || (!isDir && fileCursor < lastFile) || isDir) {
+						partial = true
+						fileCursor++
+						continue
+					}
+					// no match and not double globbing, so give up
+					return false, partial
+				}
+				// ran out of fileParts so break pattern loop
+				break
+			}
+			if pattCursor == len(pattParts) && fileCursor == len(fileParts) {
+				// all the pattern and file parts were consumed, so we have a complete match
+				return true, false
+			}
+		}
+		// partial matches are only relevant if the input is a directory, otherwise this is a failed match
+		return isDir, partial
+	}
+
+	count := strings.Count(name, string(filepath.Separator))
 	if strings.Count(pattern, string(filepath.Separator)) > count {
 		pattern = trimUntilIndex(pattern, string(filepath.Separator), count)
 		partial = true


### PR DESCRIPTION
Hi @tonistiigi, hoping for your thoughts on this PR 

 When dealing with `llb.Local` in buildkit I generally want to use doublestar `**` syntax for larger projects.  For instance, to collect the source for compiling Go code I want to use `llb.Local(".", llb.IncludePatterns([]string{"**/*.go"}))`.  Typically the workaround is to just skip the `IncludePatterns` but of course, that will invalidate the caching if any non-Go files change, which is less than ideal.  The implementation is a bit tricky, but it is only used when we find a `**` pattern, otherwise your original implementation is used.

Additionally there is a change in `Walk` that will prevent empty directories from being generated when those directories were only partial matches.  Perhaps there is something I am missing here but if you have pattern `foo/*/bar` with directory:
```
foo/a/b
foo/c/d
foo/f/bar
```
you would end up with:
```
foo/a
foo/c
foo/f/bar
```
I would not expect the `foo/a` and `foo/c` directories to show up in the result since they don't match my pattern, so I have fixed this behavior.  If this is intended behavior, I am curious what the reasoning is.

Trying to add this functionality for related issues/work in our [HLB project](https://github.com/openllb/hlb/issues/42)

[cc @hinshun]
