### PR TITLE
Drop support for go1.12, and use errors.Is() for error-detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 language: go
 
 go:
-  - "1.12.x"
   - "1.13.x"
   - "1.14.x"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ services:
 
 language: go
 
-go: 
- - "1.12.x"
+go:
+  - "1.12.x"
+  - "1.13.x"
+  - "1.14.x"
 
 install:
  - export GO111MODULE=on

--- a/stat_unix.go
+++ b/stat_unix.go
@@ -14,7 +14,7 @@ import (
 func loadXattr(origpath string, stat *types.Stat) error {
 	xattrs, err := sysx.LListxattr(origpath)
 	if err != nil {
-		if errors.Cause(err) == syscall.ENOTSUP {
+		if errors.Is(err, syscall.ENOTSUP) {
 			return nil
 		}
 		return errors.Wrapf(err, "failed to xattr %s", origpath)

--- a/walker.go
+++ b/walker.go
@@ -219,12 +219,5 @@ func trimUntilIndex(str, sep string, count int) string {
 }
 
 func isNotExist(err error) bool {
-	err = errors.Cause(err)
-	if os.IsNotExist(err) {
-		return true
-	}
-	if pe, ok := err.(*os.PathError); ok {
-		err = pe.Err
-	}
-	return err == syscall.ENOTDIR
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
 }


### PR DESCRIPTION
follow-up to https://github.com/tonistiigi/fsutil/pull/81