### PR TITLE
walker: fix notadir error

### DIFF
--- a/walker.go
+++ b/walker.go
@@ -65,17 +65,15 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 	seenFiles := make(map[uint64]string)
 	return filepath.Walk(root, func(path string, fi os.FileInfo, err error) (retErr error) {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return filepath.SkipDir
-			}
-			return err
-		}
 		defer func() {
 			if retErr != nil && isNotExist(retErr) {
 				retErr = filepath.SkipDir
 			}
 		}()
+		if err != nil {
+			return err
+		}
+
 		origpath := path
 		path, err = filepath.Rel(root, path)
 		if err != nil {


### PR DESCRIPTION
spotted on buildkit ci https://travis-ci.org/github/moby/buildkit/jobs/709029993#L3587

This was actually attempted to be fixed before but the previous fix https://github.com/tonistiigi/fsutil/pull/54/files did not take into account that stdlib could already be returning this error, therefore only narrowing the race.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>