### PR TITLE
improving error returns

### DIFF
--- a/chtimes_nolinux.go
+++ b/chtimes_nolinux.go
@@ -5,16 +5,18 @@ package fsutil
 import (
 	"os"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func chtimes(path string, un int64) error {
 	mtime := time.Unix(0, un)
 	fi, err := os.Lstat(path)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
 		return nil
 	}
-	return os.Chtimes(path, mtime, mtime)
+	return errors.WithStack(os.Chtimes(path, mtime, mtime))
 }

--- a/diff.go
+++ b/diff.go
@@ -21,7 +21,7 @@ type ContentHasher func(*types.Stat) (hash.Hash, error)
 
 func GetWalkerFn(root string) walkerFn {
 	return func(ctx context.Context, pathC chan<- *currentPath) error {
-		return Walk(ctx, root, nil, func(path string, f os.FileInfo, err error) error {
+		return errors.Wrap(Walk(ctx, root, nil, func(path string, f os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -42,7 +42,7 @@ func GetWalkerFn(root string) walkerFn {
 			case pathC <- p:
 				return nil
 			}
-		})
+		}), "failed to walk")
 	}
 }
 

--- a/diskwriter_unix.go
+++ b/diskwriter_unix.go
@@ -17,17 +17,17 @@ func rewriteMetadata(p string, stat *types.Stat) error {
 	}
 
 	if err := os.Lchown(p, int(stat.Uid), int(stat.Gid)); err != nil {
-		return errors.Wrapf(err, "failed to lchown %s", p)
+		return errors.WithStack(err)
 	}
 
 	if os.FileMode(stat.Mode)&os.ModeSymlink == 0 {
 		if err := os.Chmod(p, os.FileMode(stat.Mode)); err != nil {
-			return errors.Wrapf(err, "failed to chown %s", p)
+			return errors.WithStack(err)
 		}
 	}
 
 	if err := chtimes(p, stat.ModTime); err != nil {
-		return errors.Wrapf(err, "failed to chtimes %s", p)
+		return err
 	}
 
 	return nil
@@ -46,7 +46,7 @@ func handleTarTypeBlockCharFifo(path string, stat *types.Stat) error {
 	}
 
 	if err := syscall.Mknod(path, mode, int(mkdev(stat.Devmajor, stat.Devminor))); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }

--- a/followlinks.go
+++ b/followlinks.go
@@ -77,10 +77,10 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 	if allowWildcard && containsWildcards(base) {
 		fis, err := ioutil.ReadDir(filepath.Dir(realPath))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				return nil, nil
 			}
-			return nil, errors.Wrapf(err, "failed to read dir %s", filepath.Dir(realPath))
+			return nil, errors.Wrap(err, "readdir")
 		}
 		var out []string
 		for _, f := range fis {
@@ -97,17 +97,17 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 
 	fi, err := os.Lstat(realPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
-		return nil, errors.Wrapf(err, "failed to lstat %s", realPath)
+		return nil, errors.WithStack(err)
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
 		return nil, nil
 	}
 	link, err := os.Readlink(realPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to readlink %s", realPath)
+		return nil, errors.WithStack(err)
 	}
 	link = filepath.Clean(link)
 	if filepath.IsAbs(link) {

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -2,6 +2,7 @@ package fsutil
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
@@ -28,7 +29,7 @@ func (v *Hardlinks) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err 
 
 	stat, ok := fi.Sys().(*types.Stat)
 	if !ok {
-		return errors.Errorf("invalid change without stat info: %s", p)
+		return errors.WithStack(&os.PathError{Path: p, Err: syscall.EBADMSG, Op: "change without stat info"})
 	}
 
 	if fi.IsDir() || fi.Mode()&os.ModeSymlink != 0 {

--- a/send.go
+++ b/send.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
@@ -148,7 +149,7 @@ func (s *sender) walk(ctx context.Context) error {
 		}
 		stat, ok := fi.Sys().(*types.Stat)
 		if !ok {
-			return errors.Wrapf(err, "invalid fileinfo without stat info: %s", path)
+			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 
 		p := &types.Packet{

--- a/stat.go
+++ b/stat.go
@@ -31,13 +31,13 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 		if fi.Mode()&os.ModeSymlink != 0 {
 			link, err := os.Readlink(path)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to readlink %s", path)
+				return nil, errors.WithStack(err)
 			}
 			stat.Linkname = link
 		}
 	}
 	if err := loadXattr(path, stat); err != nil {
-		return nil, errors.Wrapf(err, "failed to xattr %s", relpath)
+		return nil, err
 	}
 
 	if runtime.GOOS == "windows" {
@@ -58,7 +58,7 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 func Stat(path string) (*types.Stat, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "os stat")
+		return nil, errors.WithStack(err)
 	}
 	return mkstat(path, filepath.Base(path), fi, nil)
 }

--- a/tarwriter.go
+++ b/tarwriter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
@@ -15,9 +16,12 @@ import (
 func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 	tw := tar.NewWriter(w)
 	err := fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 		stat, ok := fi.Sys().(*types.Stat)
 		if !ok {
-			return errors.Wrapf(err, "invalid fileinfo without stat info: %s", path)
+			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 		hdr, err := tar.FileInfoHeader(fi, stat.Linkname)
 		if err != nil {
@@ -52,7 +56,7 @@ func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 		}
 
 		if err := tw.WriteHeader(hdr); err != nil {
-			return errors.Wrap(err, "failed to write file header")
+			return errors.Wrapf(err, "failed to write file header %s", name)
 		}
 
 		if hdr.Typeflag == tar.TypeReg && hdr.Size > 0 && hdr.Linkname == "" {
@@ -61,10 +65,10 @@ func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 				return err
 			}
 			if _, err := io.Copy(tw, rc); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			if err := rc.Close(); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return nil

--- a/walker.go
+++ b/walker.go
@@ -25,21 +25,21 @@ type WalkOpt struct {
 func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) error {
 	root, err := filepath.EvalSymlinks(p)
 	if err != nil {
-		return errors.Wrapf(err, "failed to resolve %s", root)
+		return errors.WithStack(&os.PathError{Op: "resolve", Path: root, Err: err})
 	}
 	fi, err := os.Stat(root)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stat: %s", root)
+		return errors.WithStack(err)
 	}
 	if !fi.IsDir() {
-		return errors.Errorf("%s is not a directory", root)
+		return errors.WithStack(&os.PathError{Op: "walk", Path: root, Err: syscall.ENOTDIR})
 	}
 
 	var pm *fileutils.PatternMatcher
 	if opt != nil && opt.ExcludePatterns != nil {
 		pm, err = fileutils.NewPatternMatcher(opt.ExcludePatterns)
 		if err != nil {
-			return errors.Wrapf(err, "invalid excludepaths %s", opt.ExcludePatterns)
+			return errors.Wrapf(err, "invalid excludepatterns: %s", opt.ExcludePatterns)
 		}
 	}
 


### PR DESCRIPTION
Improving error returns:
- more typed errors
- remove extra verbosity (eg. PathError already contains action and path)
- ensure stack traces are added to errors

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>