### PR TITLE
copy: use Clonefileat from golang.org/x/sys/unix on macOS

### DIFF
--- a/copy/copy_darwin.go
+++ b/copy/copy_darwin.go
@@ -5,21 +5,13 @@ package fs
 import (
 	"io"
 	"os"
-	"syscall"
-	"unsafe"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
-// <sys/clonefile.h
-// int clonefileat(int, const char *, int, const char *, uint32_t) __OSX_AVAILABLE(10.12) __IOS_AVAILABLE(10.0) __TVOS_AVAILABLE(10.0) __WATCHOS_AVAILABLE(3.0);
-
-const CLONE_NOFOLLOW = 0x0001    /* Don't follow symbolic links */
-const CLONE_NOOWNERCOPY = 0x0002 /* Don't copy ownership information from */
-
 func copyFile(source, target string) error {
-	if err := clonefile(source, target); err != nil {
+	if err := unix.Clonefileat(unix.AT_FDCWD, source, unix.AT_FDCWD, target, unix.CLONE_NOFOLLOW); err != nil {
 		if err != unix.EINVAL {
 			return err
 		}
@@ -47,38 +39,4 @@ func copyFileContent(dst, src *os.File) error {
 	bufferPool.Put(buf)
 
 	return err
-}
-
-// errnoErr returns common boxed Errno values, to prevent
-// allocations at runtime.
-func errnoErr(e syscall.Errno) error {
-	switch e {
-	case 0:
-		return nil
-	case unix.EAGAIN:
-		return syscall.EAGAIN
-	case unix.EINVAL:
-		return syscall.EINVAL
-	case unix.ENOENT:
-		return syscall.ENOENT
-	}
-	return e
-}
-
-func clonefile(src, dst string) (err error) {
-	var _p0, _p1 *byte
-	_p0, err = unix.BytePtrFromString(src)
-	if err != nil {
-		return
-	}
-	_p1, err = unix.BytePtrFromString(dst)
-	if err != nil {
-		return
-	}
-	fdcwd := unix.AT_FDCWD
-	_, _, e1 := unix.Syscall6(unix.SYS_CLONEFILEAT, uintptr(fdcwd), uintptr(unsafe.Pointer(_p0)), uintptr(fdcwd), uintptr(unsafe.Pointer(_p1)), uintptr(CLONE_NOFOLLOW), 0)
-	if e1 != 0 {
-		err = errnoErr(e1)
-	}
-	return
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
+	golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20
 	gotest.tools/v3 v3.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20 h1:4X356008q5SA3YXu8PiRap39KFmy4Lf6sGlceJKZQsU=
+golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Use the `Clonefileat` wrapper from `golang.org/x/sys/unix` instead of
manually implementing it using `unix.Syscall6(SYS_CLONEFILEAT, ...)`
direct syscall which are no longer supported on macOS.