### PR TITLE
copy: add more copy_file_range exceptions

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -89,7 +89,8 @@ func copyFileContent(dst, src *os.File) error {
 
 		n, err := unix.CopyFileRange(int(src.Fd()), nil, int(dst.Fd()), nil, desired, 0)
 		if err != nil {
-			if (err != unix.ENOSYS && err != unix.EXDEV && err != unix.EPERM) || !first {
+			// matches go/src/internal/poll/copy_file_range_linux.go
+			if (err != unix.ENOSYS && err != unix.EXDEV && err != unix.EPERM && err != syscall.EIO && err != unix.EOPNOTSUPP && err != syscall.EINVAL) || !first {
 				return errors.Wrap(err, "copy file range failed")
 			}
 


### PR DESCRIPTION
closes #96

Matches go stdlib

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>