### PR TITLE
Add IncludePatterns and ExcludePatterns options for Copy

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -396,23 +396,23 @@ func (c *copier) exclude(path string, fi os.FileInfo) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "failed to match excludepatterns")
 	}
-	if m {
-		if fi.IsDir() && c.excludePatternMatcher.Exclusions() {
-			dirSlash := path + string(filepath.Separator)
-			for _, pat := range c.excludePatternMatcher.Patterns() {
-				if !pat.Exclusion() {
-					continue
-				}
-				patStr := pat.String() + string(filepath.Separator)
-				if strings.HasPrefix(patStr, dirSlash) {
-					return false, nil
-				}
-			}
-		}
-		return true, nil
+	if !m {
+		return false, nil
 	}
 
-	return false, nil
+	if fi.IsDir() && c.excludePatternMatcher.Exclusions() {
+		dirSlash := path + string(filepath.Separator)
+		for _, pat := range c.excludePatternMatcher.Patterns() {
+			if !pat.Exclusion() {
+				continue
+			}
+			patStr := pat.String() + string(filepath.Separator)
+			if strings.HasPrefix(patStr, dirSlash) {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
 }
 
 // Delayed creation of parent directories when a file or dir matches an include

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -362,7 +362,7 @@ func (c *copier) include(path string, fi os.FileInfo) (bool, bool, error) {
 			pattern = strings.TrimSuffix(pattern, string(filepath.Separator))
 		}
 
-		if ok, p := prefix.Match(pattern, path); ok {
+		if ok, p := prefix.Match(pattern, path, false); ok {
 			matched = true
 			if !p {
 				partial = false

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -457,6 +456,6 @@ func TestCopyIncludeExclude(t *testing.T) {
 			}
 		}
 
-		assert.Equal(t, tc.expectedResults, results, tc.name)
+		require.Equal(t, tc.expectedResults, results, tc.name)
 	}
 }

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -351,4 +352,111 @@ func testCopy(apply fstest.Applier) error {
 	}
 
 	return fstest.CheckDirectoryEqual(t1, t2)
+}
+
+func TestCopyIncludeExclude(t *testing.T) {
+	t1, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(t1)
+
+	apply := fstest.Apply(
+		fstest.CreateDir("bar", 0755),
+		fstest.CreateFile("bar/foo", []byte("foo-contents"), 0755),
+		fstest.CreateDir("bar/baz", 0755),
+		fstest.CreateFile("bar/baz/foo3", []byte("foo3-contents"), 0755),
+		fstest.CreateFile("foo2", []byte("foo2-contents"), 0755),
+	)
+
+	require.NoError(t, apply.Apply(t1))
+
+	testCases := []struct {
+		name            string
+		opts            []Opt
+		expectedResults []string
+	}{
+		{
+			name:            "include bar",
+			opts:            []Opt{WithIncludePattern("bar")},
+			expectedResults: []string{"bar", "bar/foo", "bar/baz", "bar/baz/foo3"},
+		},
+		{
+			name:            "include *",
+			opts:            []Opt{WithIncludePattern("*")},
+			expectedResults: []string{"bar", "bar/foo", "bar/baz", "bar/baz/foo3", "foo2"},
+		},
+		{
+			name:            "include bar/foo",
+			opts:            []Opt{WithIncludePattern("bar/foo")},
+			expectedResults: []string{"bar", "bar/foo"},
+		},
+		{
+			name:            "include bar/foo and foo*",
+			opts:            []Opt{WithIncludePattern("bar/foo"), WithIncludePattern("foo*")},
+			expectedResults: []string{"bar", "bar/foo", "foo2"},
+		},
+		{
+			name:            "include b*",
+			opts:            []Opt{WithIncludePattern("b*")},
+			expectedResults: []string{"bar", "bar/foo", "bar/baz", "bar/baz/foo3"},
+		},
+		{
+			name:            "include bar/f*",
+			opts:            []Opt{WithIncludePattern("bar/f*")},
+			expectedResults: []string{"bar", "bar/foo"},
+		},
+		{
+			name:            "include bar/g*",
+			opts:            []Opt{WithIncludePattern("bar/g*")},
+			expectedResults: nil,
+		},
+		{
+			name:            "include b*/f*",
+			opts:            []Opt{WithIncludePattern("b*/f*")},
+			expectedResults: []string{"bar", "bar/foo"},
+		},
+		{
+			name:            "include b*/foo",
+			opts:            []Opt{WithIncludePattern("b*/foo")},
+			expectedResults: []string{"bar", "bar/foo"},
+		},
+		{
+			name:            "include b*/",
+			opts:            []Opt{WithIncludePattern("b*/")},
+			expectedResults: []string{"bar", "bar/foo", "bar/baz", "bar/baz/foo3"},
+		},
+		{
+			name:            "include bar/*/foo3",
+			opts:            []Opt{WithIncludePattern("bar/*/foo3")},
+			expectedResults: []string{"bar", "bar/baz", "bar/baz/foo3"},
+		},
+		{
+			name:            "exclude bar*, !bar/baz",
+			opts:            []Opt{WithExcludePattern("bar*"), WithExcludePattern("!bar/baz")},
+			expectedResults: []string{"bar", "bar/baz", "bar/baz/foo3", "foo2"},
+		},
+		{
+			name:            "include bar, exclude bar/baz",
+			opts:            []Opt{WithIncludePattern("bar"), WithExcludePattern("bar/baz")},
+			expectedResults: []string{"bar", "bar/foo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t2, err := ioutil.TempDir("", "test")
+		require.NoError(t, err)
+		defer os.RemoveAll(t2)
+
+		err = Copy(context.Background(), t1, "/", t2, "/", tc.opts...)
+		require.NoError(t, err)
+
+		var results []string
+		for _, path := range []string{"bar", "bar/foo", "bar/baz", "bar/baz/foo3", "foo2"} {
+			_, err := os.Stat(filepath.Join(t2, path))
+			if err == nil {
+				results = append(results, path)
+			}
+		}
+
+		assert.Equal(t, tc.expectedResults, results, tc.name)
+	}
 }

--- a/prefix/match.go
+++ b/prefix/match.go
@@ -1,18 +1,28 @@
 package prefix
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 )
 
-func Match(pattern, name string) (bool, bool) {
-	count := strings.Count(name, string(filepath.Separator))
+func Match(pattern, name string, slashSeparator bool) (bool, bool) {
+	separator := filepath.Separator
+	if slashSeparator {
+		separator = '/'
+	}
+	count := strings.Count(name, string(separator))
 	partial := false
-	if strings.Count(pattern, string(filepath.Separator)) > count {
-		pattern = trimUntilIndex(pattern, string(filepath.Separator), count)
+	if strings.Count(pattern, string(separator)) > count {
+		pattern = trimUntilIndex(pattern, string(separator), count)
 		partial = true
 	}
-	m, _ := filepath.Match(pattern, name)
+	var m bool
+	if slashSeparator {
+		m, _ = path.Match(pattern, name)
+	} else {
+		m, _ = filepath.Match(pattern, name)
+	}
 	return m, partial
 }
 

--- a/prefix/match.go
+++ b/prefix/match.go
@@ -1,0 +1,32 @@
+package prefix
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func Match(pattern, name string) (bool, bool) {
+	count := strings.Count(name, string(filepath.Separator))
+	partial := false
+	if strings.Count(pattern, string(filepath.Separator)) > count {
+		pattern = trimUntilIndex(pattern, string(filepath.Separator), count)
+		partial = true
+	}
+	m, _ := filepath.Match(pattern, name)
+	return m, partial
+}
+
+func trimUntilIndex(str, sep string, count int) string {
+	s := str
+	i := 0
+	c := 0
+	for {
+		idx := strings.Index(s, sep)
+		s = s[idx+len(sep):]
+		i += idx + len(sep)
+		c++
+		if c > count {
+			return str[:i-len(sep)]
+		}
+	}
+}

--- a/prefix/match.go
+++ b/prefix/match.go
@@ -6,18 +6,21 @@ import (
 	"strings"
 )
 
-func Match(pattern, name string, slashSeparator bool) (bool, bool) {
+// Match matches a path against a pattern. It returns m = true if the path
+// matches the pattern, and partial = true if the pattern has more separators
+// than the path and the common components match (for example, name = foo and
+// pattern = foo/bar/*). slashSeparator determines whether the path and pattern
+// are '/' delimited (true) or use the native path separator (false).
+func Match(pattern, name string, slashSeparator bool) (m bool, partial bool) {
 	separator := filepath.Separator
 	if slashSeparator {
 		separator = '/'
 	}
 	count := strings.Count(name, string(separator))
-	partial := false
 	if strings.Count(pattern, string(separator)) > count {
 		pattern = trimUntilIndex(pattern, string(separator), count)
 		partial = true
 	}
-	var m bool
 	if slashSeparator {
 		m, _ = path.Match(pattern, name)
 	} else {

--- a/prefix/match_test.go
+++ b/prefix/match_test.go
@@ -7,51 +7,51 @@ import (
 )
 
 func TestMatch(t *testing.T) {
-	ok, partial := Match("foo", "foo")
+	ok, partial := Match("foo", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, partial)
 
-	ok, partial = Match("foo/bar/baz", "foo")
+	ok, partial = Match("foo/bar/baz", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("foo/bar/baz", "foo/bar")
+	ok, partial = Match("foo/bar/baz", "foo/bar", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("foo/bar/baz", "foo/bax")
+	ok, partial = Match("foo/bar/baz", "foo/bax", false)
 	assert.Equal(t, false, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("foo/bar/baz", "foo/bar/baz")
+	ok, partial = Match("foo/bar/baz", "foo/bar/baz", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, partial)
 
-	ok, partial = Match("f*", "foo")
+	ok, partial = Match("f*", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, partial)
 
-	ok, partial = Match("foo/bar/*", "foo")
+	ok, partial = Match("foo/bar/*", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("foo/*/baz", "foo")
+	ok, partial = Match("foo/*/baz", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("*/*/baz", "foo")
+	ok, partial = Match("*/*/baz", "foo", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("*/bar/baz", "foo/bar")
+	ok, partial = Match("*/bar/baz", "foo/bar", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("*/bar/baz", "foo/bax")
+	ok, partial = Match("*/bar/baz", "foo/bax", false)
 	assert.Equal(t, false, ok)
 	assert.Equal(t, true, partial)
 
-	ok, partial = Match("*/*/baz", "foo/bar/baz")
+	ok, partial = Match("*/*/baz", "foo/bar/baz", false)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, partial)
 }

--- a/prefix/match_test.go
+++ b/prefix/match_test.go
@@ -1,0 +1,57 @@
+package prefix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatch(t *testing.T) {
+	ok, partial := Match("foo", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, partial)
+
+	ok, partial = Match("foo/bar/baz", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("foo/bar/baz", "foo/bar")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("foo/bar/baz", "foo/bax")
+	assert.Equal(t, false, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("foo/bar/baz", "foo/bar/baz")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, partial)
+
+	ok, partial = Match("f*", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, partial)
+
+	ok, partial = Match("foo/bar/*", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("foo/*/baz", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("*/*/baz", "foo")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("*/bar/baz", "foo/bar")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("*/bar/baz", "foo/bax")
+	assert.Equal(t, false, ok)
+	assert.Equal(t, true, partial)
+
+	ok, partial = Match("*/*/baz", "foo/bar/baz")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, partial)
+}

--- a/walker.go
+++ b/walker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil/prefix"
 	"github.com/tonistiigi/fsutil/types"
 )
 
@@ -96,8 +97,8 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 				if !skip {
 					matched := false
 					partial := true
-					for _, p := range includePatterns {
-						if ok, p := matchPrefix(p, path); ok {
+					for _, pattern := range includePatterns {
+						if ok, p := prefix.Match(pattern, path); ok {
 							matched = true
 							if !p {
 								partial = false
@@ -188,32 +189,6 @@ func (s *StatInfo) IsDir() bool {
 }
 func (s *StatInfo) Sys() interface{} {
 	return s.Stat
-}
-
-func matchPrefix(pattern, name string) (bool, bool) {
-	count := strings.Count(name, string(filepath.Separator))
-	partial := false
-	if strings.Count(pattern, string(filepath.Separator)) > count {
-		pattern = trimUntilIndex(pattern, string(filepath.Separator), count)
-		partial = true
-	}
-	m, _ := filepath.Match(pattern, name)
-	return m, partial
-}
-
-func trimUntilIndex(str, sep string, count int) string {
-	s := str
-	i := 0
-	c := 0
-	for {
-		idx := strings.Index(s, sep)
-		s = s[idx+len(sep):]
-		i += idx + len(sep)
-		c++
-		if c > count {
-			return str[:i-len(sep)]
-		}
-	}
 }
 
 func isNotExist(err error) bool {

--- a/walker.go
+++ b/walker.go
@@ -98,7 +98,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 					matched := false
 					partial := true
 					for _, pattern := range includePatterns {
-						if ok, p := prefix.Match(pattern, path); ok {
+						if ok, p := prefix.Match(pattern, path, false); ok {
 							matched = true
 							if !p {
 								partial = false

--- a/walker_test.go
+++ b/walker_test.go
@@ -149,7 +149,6 @@ func TestWalkerExclude(t *testing.T) {
 dir foo
 file foo/bar2
 `, string(b.Bytes()))
-
 }
 
 func TestWalkerFollowLinks(t *testing.T) {
@@ -232,56 +231,6 @@ func TestWalkerMap(t *testing.T) {
 file _foo/bar2
 file _foo2
 `, string(b.Bytes()))
-}
-
-func TestMatchPrefix(t *testing.T) {
-	ok, partial := matchPrefix("foo", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, false, partial)
-
-	ok, partial = matchPrefix("foo/bar/baz", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("foo/bar/baz", "foo/bar")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("foo/bar/baz", "foo/bax")
-	assert.Equal(t, false, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("foo/bar/baz", "foo/bar/baz")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, false, partial)
-
-	ok, partial = matchPrefix("f*", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, false, partial)
-
-	ok, partial = matchPrefix("foo/bar/*", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("foo/*/baz", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("*/*/baz", "foo")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("*/bar/baz", "foo/bar")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("*/bar/baz", "foo/bax")
-	assert.Equal(t, false, ok)
-	assert.Equal(t, true, partial)
-
-	ok, partial = matchPrefix("*/*/baz", "foo/bar/baz")
-	assert.Equal(t, true, ok)
-	assert.Equal(t, false, partial)
 }
 
 func bufWalk(buf *bytes.Buffer) filepath.WalkFunc {


### PR DESCRIPTION
Allow include patterns and exclude patterns to be specified, similarly
to `Walker`.

There is a bit of extra complexity to handle the case of a pattern like
`a/*/c`. In this case, creating the directories `a` and `a/b` may need
to be delayed until we encounter `a/b/c`.

cc @hinshun