### PR TITLE
Use PatternMatcher for copy include patterns as well as exclude patterns

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -321,7 +321,7 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 
 	switch {
 	case fi.IsDir():
-		if created, err := c.copyDirectory(ctx, src, srcComponents, target, fi, overwriteTargetMetadata, skipIncludePatterns); err != nil {
+		if created, err := c.copyDirectory(ctx, src, srcComponents, target, fi, overwriteTargetMetadata, skipIncludePatterns, include); err != nil {
 			return err
 		} else if !overwriteTargetMetadata || !skipIncludePatterns {
 			copyFileInfo = created
@@ -426,7 +426,7 @@ func (c *copier) createParentDirs(src, srcComponents, target string, overwriteTa
 	return nil
 }
 
-func (c *copier) copyDirectory(ctx context.Context, src, srcComponents, dst string, stat os.FileInfo, overwriteTargetMetadata, skipIncludePatterns bool) (bool, error) {
+func (c *copier) copyDirectory(ctx context.Context, src, srcComponents, dst string, stat os.FileInfo, overwriteTargetMetadata, skipIncludePatterns, matchedExactly bool) (bool, error) {
 	if !stat.IsDir() {
 		return false, errors.Errorf("source is not directory")
 	}
@@ -437,7 +437,7 @@ func (c *copier) copyDirectory(ctx context.Context, src, srcComponents, dst stri
 	// pattern exactly, go ahead and create the directory. Otherwise, delay to
 	// handle include patterns like a/*/c where we do not want to create a/b
 	// until we encounter a/b/c.
-	if skipIncludePatterns {
+	if matchedExactly || skipIncludePatterns {
 		var err error
 		created, err = copyDirectoryOnly(src, dst, stat, overwriteTargetMetadata)
 		if err != nil {

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -389,6 +389,11 @@ func TestCopyIncludeExclude(t *testing.T) {
 			expectedResults: []string{"bar", "bar/foo"},
 		},
 		{
+			name:            "include bar except bar/foo",
+			opts:            []Opt{WithIncludePattern("bar"), WithIncludePattern("!bar/foo")},
+			expectedResults: []string{"bar", "bar/baz", "bar/baz/foo3"},
+		},
+		{
 			name:            "include bar/foo and foo*",
 			opts:            []Opt{WithIncludePattern("bar/foo"), WithIncludePattern("foo*")},
 			expectedResults: []string{"bar", "bar/foo", "foo2"},

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -443,6 +443,16 @@ func TestCopyIncludeExclude(t *testing.T) {
 			opts:            []Opt{WithIncludePattern("bar"), WithExcludePattern("bar/baz")},
 			expectedResults: []string{"bar", "bar/foo"},
 		},
+		{
+			name:            "doublestar include",
+			opts:            []Opt{WithIncludePattern("**/foo3")},
+			expectedResults: []string{"bar", "bar/baz", "bar/baz/foo3"},
+		},
+		{
+			name:            "doublestar exclude",
+			opts:            []Opt{WithIncludePattern("bar"), WithExcludePattern("**/foo3")},
+			expectedResults: []string{"bar", "bar/foo", "bar/baz"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This changes the logic for copy's "include patterns" to use
`PatternMatcher`, so it behaves the same as "exclude patterns". This is a
net simplification and provides more consistency between the two
parameters (for example, include patterns can now specify negative
matches), but is a bit worse performance-wise (we can't skip a directory
which fails to partially match a pattern, because files inside it may
match the pattern).

cc @hinshun