### PR TITLE
FreeBSD port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,21 @@ jobs:
         name: Cross
         run: |
           docker buildx bake cross
+
+  test-freebsd-amd64:
+    runs-on: macos-latest
+    env:
+      VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13
+    steps:
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('hack/Vagrantfile.freebsd13') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+      - uses: actions/checkout@v2
+      - name: Set up vagrant
+        run: vagrant up
+      - name: "Run unit tests"
+        run: vagrant ssh -- "cd /vagrant; go test ./..."

--- a/copy/copy_freebsd.go
+++ b/copy/copy_freebsd.go
@@ -1,0 +1,32 @@
+// +build freebsd
+
+package fs
+
+import (
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func copyFile(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open source %s", source)
+	}
+	defer src.Close()
+	tgt, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open target %s", target)
+	}
+	defer tgt.Close()
+
+	return copyFileContent(tgt, src)
+}
+
+func copyFileContent(dst, src *os.File) error {
+	buf := bufferPool.Get().(*[]byte)
+	_, err := io.CopyBuffer(dst, src, *buf)
+	bufferPool.Put(buf)
+	return err
+}

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -57,5 +57,5 @@ func copyDevice(dst string, fi os.FileInfo) error {
 	if !ok {
 		return errors.New("unsupported stat type")
 	}
-	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
 }

--- a/diskwriter_freebsd.go
+++ b/diskwriter_freebsd.go
@@ -1,0 +1,14 @@
+// +build freebsd
+
+package fsutil
+
+import (
+	"github.com/tonistiigi/fsutil/types"
+	"golang.org/x/sys/unix"
+)
+
+func createSpecialFile(path string, mode uint32, stat *types.Stat) error {
+	dev := unix.Mkdev(uint32(stat.Devmajor), uint32(stat.Devminor))
+
+	return unix.Mknod(path, mode, dev)
+}

--- a/diskwriter_unix.go
+++ b/diskwriter_unix.go
@@ -45,7 +45,7 @@ func handleTarTypeBlockCharFifo(path string, stat *types.Stat) error {
 		mode |= syscall.S_IFBLK
 	}
 
-	if err := syscall.Mknod(path, mode, int(mkdev(stat.Devmajor, stat.Devminor))); err != nil {
+	if err := createSpecialFile(path, mode, stat); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/diskwriter_unixnobsd.go
+++ b/diskwriter_unixnobsd.go
@@ -1,0 +1,13 @@
+// +build !windows,!freebsd
+
+package fsutil
+
+import (
+	"syscall"
+
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func createSpecialFile(path string, mode uint32, stat *types.Stat) error {
+	return syscall.Mknod(path, mode, int(mkdev(stat.Devmajor, stat.Devminor)))
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -63,5 +63,5 @@ target "shfmt" {
 
 target "cross" {
   inherits = ["build"]
-  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "freebsd/amd64"]
 }

--- a/hack/Vagrantfile.freebsd13
+++ b/hack/Vagrantfile.freebsd13
@@ -1,0 +1,37 @@
+# This code is taken from the Vagrantfile from libjail-rs
+# https://github.com/fubarnetes/libjail-rs/blob/727353bd6565c5e7a9be2664258d0197a1c8bb35/Vagrantfile
+# licensed under BSD-3 Clause License:
+# BSD 3-Clause License
+
+# Copyright (c) 2018, Fabian Freyer <fabian.freyer@physik.tu-berlin.de> All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Vagrant.configure("2") do |config|
+  # Unreleased version
+  #
+  # config.vm.define "fbsd_14_0" do |fbsd_14_0|
+  #   fbsd_14_0.vm.box = "freebsd/FreeBSD-14.0-CURRENT"
+  # end
+
+  # Stable version
+  #
+  config.vm.define "fbsd_13_0" do |fbsd_13_0|
+    fbsd_13_0.vm.box = "freebsd/FreeBSD-13.0-STABLE"
+  end
+
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
+
+  config.vm.provision "shell", inline: <<-SHELL
+    pkg bootstrap
+    pkg install -y go
+  SHELL
+end

--- a/receive_test.go
+++ b/receive_test.go
@@ -455,6 +455,9 @@ func simpleSHA256Hasher(s *types.Stat) (hash.Hash, error) {
 	h := sha256.New()
 	ss := *s
 	ss.ModTime = 0
+	// Unlike Linux, on FreeBSD's stat() call returns -1 in st_rdev for regular files
+	ss.Devminor = 0
+	ss.Devmajor = 0
 
 	if os.FileMode(ss.Mode)&os.ModeSymlink != 0 {
 		ss.Mode = ss.Mode | 0777


### PR DESCRIPTION
Currently `copy` and `diskwriter` packages can't be built on FreeBSD:

- copy package lacks implementation of `copyFile` & `copyFileContent`
  functions.
- diskwriter package assumes 32-bit device nodes, and FreeBSD uses 64
  ones.

This change

* Fixes FreeBSD build issues
* Fixes tests
* Introduces a GH Actions job to run tests on FreeBSD.

Signed-off-by: Artem Khramov <akhramov@pm.me>