### PR TITLE
fix darwin build and make sure it is enabled on cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        GO_VERSION: ["1.13", "1.14", "1.15", "1.16"]
+        GO_VERSION: ["1.16", "1.17"]
     env:
       GO_VERSION: ${{ matrix.GO_VERSION }}
     steps:

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -1,3 +1,4 @@
+//go:build solaris || darwin || freebsd
 // +build solaris darwin freebsd
 
 package fs
@@ -50,12 +51,4 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 	return nil
-}
-
-func copyDevice(dst string, fi os.FileInfo) error {
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("unsupported stat type")
-	}
-	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
 }

--- a/copy/device_darwin.go
+++ b/copy/device_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+// +build darwin
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+}

--- a/copy/device_freebsd.go
+++ b/copy/device_freebsd.go
@@ -1,0 +1,20 @@
+//go:build freebsd || solaris
+// +build freebsd solaris
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -63,5 +63,5 @@ target "shfmt" {
 
 target "cross" {
   inherits = ["build"]
-  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "freebsd/amd64"]
+  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "darwin/amd64", "darwin/arm64", "windows/amd64", "freebsd/amd64", "freebsd/arm64"]
 }


### PR DESCRIPTION
Looks like this broke in #109 and surprisingly darwin target was missing in cross and didn't catch it

@akhramov 

@crazy-max When you have free cycles feel free to add direct darwin worker(and windows if possible) in CI to run `go test`. I thought this was already the case but looks like freebsd is the only special case. 