### PR TITLE
return when io.CopyBuffer finishes

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -100,6 +100,7 @@ func copyFileContent(dst, src *os.File) error {
 			if err != nil {
 				return errors.Wrap(err, "userspace copy failed")
 			}
+			return nil
 		}
 
 		first = false


### PR DESCRIPTION
This is a follow up to abe942fbd8b232a2a4ffac5226264af1dc08a0e5

where I missed the final `return nil` from https://github.com/containerd/continuity/commit/23a11df3824c0e2868cff8775369f3cbd3430226
for the cases where no error occurs and the fallback userspace copy succeeded

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>