### PR TITLE
fix(ci): vagrant not available on macos 11 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           go test ./...
 
   test-freebsd-amd64:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
       VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13
     steps:


### PR DESCRIPTION
fixes #118 

Looks like PR to add vagrant/virtualbox on MacOS 11 runners has been closed https://github.com/actions/virtual-environments/pull/4010 so in the meantime use `macos-10.15` [as suggested](https://github.com/actions/virtual-environments/issues/4060#issuecomment-950757410).

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>