### PR TITLE
hack: add gcc back to lint

### DIFF
--- a/hack/dockerfiles/lint.Dockerfile
+++ b/hack/dockerfiles/lint.Dockerfile
@@ -2,7 +2,7 @@
 ARG GO_VERSION=1.18
 
 FROM golang:${GO_VERSION}-alpine
-RUN apk add --no-cache git
+RUN apk add --no-cache git gcc musl-dev
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.45.2
 WORKDIR /go/src/github.com/tonistiigi/fsutil
 RUN --mount=target=/go/src/github.com/tonistiigi/fsutil --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \


### PR DESCRIPTION
Something bizarre going on here that I don't really understand.

Without `gcc` being present linter will show following warnings:

```
#27 5.475 copy/copy.go:399:19: invalid operation: cannot compare c.changefn != nil (operator != not defined on untyped nil) (typecheck)
#27 5.475 	if c.changefn != nil {
#27 5.476 	                 ^
#27 5.477 copy/copy.go:7:2: "path" imported but not used (typecheck)
#27 5.477 	"path"
#27 5.477 	^
#27 5.478 ../../../../../usr/local/go/src/runtime/cgo/cgo.go:34:8: could not import C (cgo preprocessing failed) (typecheck)
#27 5.478 import "C"
#27 5.479        ^
```

These don't make sense to me. First could be lack of understanding of types by the linter, second one is just wrong because `path` is used. This will only happen when there is not previous go-cache. This is why atm the CI is green but when linter runs on its own from empty state it would not pass.



Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>