### PR TITLE
copy: don't copy file info of non-existent dir.

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -335,7 +335,7 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 		}
 	}
 
-	copyFileInfo := true
+	copyFileInfo := include
 	notify := true
 
 	switch {
@@ -345,7 +345,9 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 			include, includeMatchInfo, excludeMatchInfo,
 		); err != nil {
 			return err
-		} else if !overwriteTargetMetadata || c.includePatternMatcher != nil {
+		} else if !overwriteTargetMetadata {
+			// if we aren't supposed to overwrite existing target metadata,
+			// then we only need to copy file info if we newly created it
 			copyFileInfo = created
 		}
 		notify = false

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -572,6 +572,12 @@ func TestCopyIncludeExclude(t *testing.T) {
 			expectedResults: []string{"bar", "bar/foo", "bar/baz"},
 			expectedChanges: "add:/bar,add:/bar/baz,add:/bar/foo",
 		},
+		{
+			name:            "exclude bar/baz",
+			opts:            []Opt{WithExcludePattern("bar/baz")},
+			expectedResults: []string{"bar", "bar/foo", "foo2"},
+			expectedChanges: "add:/bar,add:/bar/foo,add:/foo2",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Before this, if a directory was excluded, copy would still end up
getting called with overwriteTargetMetadata=true in the code path where
subdirs of the root of the src are iterated over. This meant that even
though the target directory was never created and never existed, the
copyFileInfo bool would stay its default value of true and the code
would try to copy file info to a directory that doesn't exist.

This update just adds a check to see if the target dir actually exists
and sets copyFileInfo to false if not.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>