### PR TITLE
Add Windows file ownership code

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -153,6 +153,7 @@ func (c *copier) prepareTargetDir(srcFollowed, src, destPath string, copyDirCont
 
 type User struct {
 	UID, GID int
+	SID      string
 }
 
 type Chowner func(*User) (*User, error)
@@ -386,7 +387,7 @@ func (c *copier) copy(ctx context.Context, src, srcComponents, target string, ov
 	}
 
 	if copyFileInfo {
-		if err := c.copyFileInfo(fi, target); err != nil {
+		if err := c.copyFileInfo(fi, src, target); err != nil {
 			return errors.Wrap(err, "failed to copy file info")
 		}
 
@@ -460,7 +461,7 @@ func (c *copier) createParentDirs(src, srcComponents, target string, overwriteTa
 			return err
 		}
 		if created {
-			if err := c.copyFileInfo(fi, parentDir.dstPath); err != nil {
+			if err := c.copyFileInfo(fi, parentDir.srcPath, parentDir.dstPath); err != nil {
 				return errors.Wrap(err, "failed to copy file info")
 			}
 

--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -15,7 +15,7 @@ func getUIDGID(fi os.FileInfo) (uid, gid int) {
 	return int(st.Uid), int(st.Gid)
 }
 
-func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
+func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 	chown := c.chown
 	uid, gid := getUIDGID(fi)
 	old := &User{UID: uid, GID: gid}

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -16,7 +16,7 @@ func getUIDGID(fi os.FileInfo) (uid, gid int) {
 	return int(st.Uid), int(st.Gid)
 }
 
-func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
+func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 	chown := c.chown
 	uid, gid := getUIDGID(fi)
 	old := &User{UID: uid, GID: gid}

--- a/copy/copy_windows.go
+++ b/copy/copy_windows.go
@@ -4,16 +4,56 @@ import (
 	"io"
 	"os"
 
+	"github.com/Microsoft/go-winio"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
-func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
+const (
+	seTakeOwnershipPrivilege = "SeTakeOwnershipPrivilege"
+)
+
+func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 	if err := os.Chmod(name, fi.Mode()); err != nil {
 		return errors.Wrapf(err, "failed to chmod %s", name)
 	}
 
-	// TODO: copy windows specific metadata
+	// Copy file ownership and ACL
+	// We need SeRestorePrivilege and SeTakeOwnershipPrivilege in order
+	// to restore security info on a file, especially if we're trying to
+	// apply security info which includes SIDs not necessarily present on
+	// the host.
+	privileges := []string{winio.SeRestorePrivilege, seTakeOwnershipPrivilege}
+	if err := winio.EnableProcessPrivileges(privileges); err != nil {
+		return err
+	}
+	defer winio.DisableProcessPrivileges(privileges)
 
+	secInfo, err := windows.GetNamedSecurityInfo(
+		src, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+
+	if err != nil {
+		return err
+	}
+
+	dacl, _, err := secInfo.DACL()
+	if err != nil {
+		return err
+	}
+
+	sid, _, err := secInfo.Owner()
+	if err != nil {
+		return err
+	}
+
+	if err := windows.SetNamedSecurityInfo(
+		name, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+		sid, nil, dacl, nil); err != nil {
+
+		return err
+	}
 	return nil
 }
 

--- a/copy/mkdir.go
+++ b/copy/mkdir.go
@@ -4,25 +4,7 @@ import (
 	"os"
 	"syscall"
 	"time"
-
-	"github.com/pkg/errors"
 )
-
-func Chown(p string, old *User, fn Chowner) error {
-	if fn == nil {
-		return nil
-	}
-	user, err := fn(old)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if user != nil {
-		if err := os.Lchown(p, user.UID, user.GID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // MkdirAll is forked os.MkdirAll
 func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) error {

--- a/copy/mkdir_unix.go
+++ b/copy/mkdir_unix.go
@@ -4,6 +4,7 @@
 package fs
 
 import (
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,5 +30,21 @@ func Utimes(p string, tm *time.Time) error {
 		return errors.Wrapf(err, "failed to utime %s", p)
 	}
 
+	return nil
+}
+
+func Chown(p string, old *User, fn Chowner) error {
+	if fn == nil {
+		return nil
+	}
+	user, err := fn(old)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if user != nil {
+		if err := os.Lchown(p, user.UID, user.GID); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/copy/mkdir_windows.go
+++ b/copy/mkdir_windows.go
@@ -1,10 +1,21 @@
+//go:build windows
 // +build windows
 
 package fs
 
 import (
+	"fmt"
 	"os"
+	"syscall"
 	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	containerAdministratorSidString = "S-1-5-93-2-1"
 )
 
 func fixRootDirectory(p string) string {
@@ -17,5 +28,66 @@ func fixRootDirectory(p string) string {
 }
 
 func Utimes(p string, tm *time.Time) error {
+	return nil
+}
+
+func Chown(p string, old *User, fn Chowner) error {
+	if fn == nil {
+		return nil
+	}
+	user, err := fn(old)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	userSIDstring := user.SID
+	if userSIDstring == "" {
+		userSIDstring = containerAdministratorSidString
+
+	}
+	// Copy file ownership and ACL
+	// We need SeRestorePrivilege and SeTakeOwnershipPrivilege in order
+	// to restore security info on a file, especially if we're trying to
+	// apply security info which includes SIDs not necessarily present on
+	// the host.
+	privileges := []string{winio.SeRestorePrivilege, seTakeOwnershipPrivilege}
+	if err := winio.EnableProcessPrivileges(privileges); err != nil {
+		return err
+	}
+	defer winio.DisableProcessPrivileges(privileges)
+
+	sidPtr, err := syscall.UTF16PtrFromString(userSIDstring)
+	if err != nil {
+		return errors.Wrap(err, "converting to utf16 ptr")
+	}
+	var userSID *windows.SID
+	if err := windows.ConvertStringSidToSid(sidPtr, &userSID); err != nil {
+		return errors.Wrap(err, "converting to windows SID")
+	}
+	var dacl *windows.ACL
+	newEntries := []windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeValue: windows.TrusteeValueFromSID(userSID),
+			},
+		},
+	}
+	newAcl, err := windows.ACLFromEntries(newEntries, dacl)
+	if err != nil {
+		return fmt.Errorf("adding acls: %w", err)
+	}
+
+	if err := windows.SetNamedSecurityInfo(
+		p, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+		userSID, nil, newAcl, nil); err != nil {
+
+		return err
+	}
+
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tonistiigi/fsutil
 go 1.18
 
 require (
+	github.com/Microsoft/go-winio v0.5.2
 	github.com/containerd/continuity v0.3.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/moby/patternmatcher v0.5.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
This change adds the ability to copy Windows file ownership and security information, as well as implement proper Chown() for Windows.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>