### PR TITLE
copy: restore parent directory timestamp after copying contents

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -16,8 +16,6 @@ func getUIDGID(fi os.FileInfo) (uid, gid int) {
 }
 
 func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
-	st := fi.Sys().(*syscall.Stat_t)
-
 	chown := c.chown
 	uid, gid := getUIDGID(fi)
 	old := &User{UID: uid, GID: gid}
@@ -40,17 +38,23 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
-	if c.utime != nil {
-		if err := Utimes(name, c.utime); err != nil {
-			return err
-		}
-	} else {
-		timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
-		if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return errors.Wrapf(err, "failed to utime %s", name)
-		}
+	if err := c.copyFileTimestamp(fi, name); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
+	if c.utime != nil {
+		return Utimes(name, c.utime)
+	}
+
+	st := fi.Sys().(*syscall.Stat_t)
+	timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.Wrapf(err, "failed to utime %s", name)
+	}
 	return nil
 }
 

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -17,7 +17,6 @@ func getUIDGID(fi os.FileInfo) (uid, gid int) {
 }
 
 func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
-	st := fi.Sys().(*syscall.Stat_t)
 	chown := c.chown
 	uid, gid := getUIDGID(fi)
 	old := &User{UID: uid, GID: gid}
@@ -40,15 +39,21 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
+	if err := c.copyFileTimestamp(fi, name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
 	if c.utime != nil {
-		if err := Utimes(name, c.utime); err != nil {
-			return err
-		}
-	} else {
-		timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
-		if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return errors.Wrapf(err, "failed to utime %s", name)
-		}
+		return Utimes(name, c.utime)
+	}
+
+	st := fi.Sys().(*syscall.Stat_t)
+	timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.Wrapf(err, "failed to utime %s", name)
 	}
 	return nil
 }

--- a/copy/copy_windows.go
+++ b/copy/copy_windows.go
@@ -17,6 +17,12 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 	return nil
 }
 
+func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
+	// TODO: copy windows specific metadata
+
+	return nil
+}
+
 func copyFile(source, target string) error {
 	src, err := os.Open(source)
 	if err != nil {


### PR DESCRIPTION
:hammer_and_wrench: Fixes https://github.com/moby/buildkit/issues/2884

We need to restore the previous directory `FileInfo` if it existed prior to attempting to copy content into it.