### PR TITLE
Always use buf in CopyBuffer

### DIFF
--- a/send.go
+++ b/send.go
@@ -135,7 +135,7 @@ func (s *sender) sendFile(h *sendHandle) error {
 		defer f.Close()
 		buf := bufPool.Get().(*[]byte)
 		defer bufPool.Put(buf)
-		if _, err := io.CopyBuffer(&fileSender{sender: s, id: h.id}, f, *buf); err != nil {
+		if _, err := io.CopyBuffer(&fileSender{sender: s, id: h.id}, struct{ io.Reader }{f}, *buf); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
CopyBuffer may not always use the provided buffer, in the case that the src implements WriterTo. So, in the case that the io.ReadCloser returned by fs.Open implements this method, the packet size limit will not be enforced, creating an oversized packet that results in an error on the receiver.

To avoid this, we can create an anonymous structure to wrap the src, which prevents the shortcut taken by the standard library.

I'm not 100% sure of the approach for this, maybe we should write our own `Copy` method to circumvent this issue instead?

cc @crazy-max