### PR TITLE
Fix copy on windows plus tests

### DIFF
--- a/bench/go.mod
+++ b/bench/go.mod
@@ -3,7 +3,7 @@ module github.com/tonistiigi/fsutil/bench
 go 1.18
 
 require (
-	github.com/containerd/continuity v0.3.0
+	github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/tonistiigi/fsutil v0.0.0-00010101000000-000000000000

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -140,8 +140,8 @@ github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cE
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
-github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
-github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
+github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8 h1:EdSQb65ohzz4jsyPOhxfu3/+c9nnU0euk0otferwl9A=
+github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=

--- a/copy/copy_unix_test.go
+++ b/copy/copy_unix_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+// +build !windows
+
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestCopyDevicesAndFifo(t *testing.T) {
+	requiresRoot(t)
+
+	t1 := t.TempDir()
+
+	err := mknod(filepath.Join(t1, "char"), unix.S_IFCHR|0444, int(unix.Mkdev(1, 9)))
+	require.NoError(t, err)
+
+	err = mknod(filepath.Join(t1, "block"), unix.S_IFBLK|0441, int(unix.Mkdev(3, 2)))
+	require.NoError(t, err)
+
+	err = mknod(filepath.Join(t1, "socket"), unix.S_IFSOCK|0555, 0)
+	require.NoError(t, err)
+
+	err = unix.Mkfifo(filepath.Join(t1, "fifo"), 0555)
+	require.NoError(t, err)
+
+	t2 := t.TempDir()
+
+	err = Copy(context.TODO(), t1, ".", t2, ".")
+	require.NoError(t, err)
+
+	fi, err := os.Lstat(filepath.Join(t2, "char"))
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeCharDevice, fi.Mode()&os.ModeCharDevice)
+	assert.Equal(t, os.FileMode(0444), fi.Mode()&0777)
+
+	fi, err = os.Lstat(filepath.Join(t2, "block"))
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeDevice, fi.Mode()&os.ModeDevice)
+	assert.Equal(t, os.FileMode(0441), fi.Mode()&0777)
+
+	fi, err = os.Lstat(filepath.Join(t2, "fifo"))
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeNamedPipe, fi.Mode()&os.ModeNamedPipe)
+	assert.Equal(t, os.FileMode(0555), fi.Mode()&0777)
+
+	fi, err = os.Lstat(filepath.Join(t2, "socket"))
+	require.NoError(t, err)
+	assert.NotEqual(t, os.ModeSocket, fi.Mode()&os.ModeSocket) // socket copied as stub
+	assert.Equal(t, os.FileMode(0555), fi.Mode()&0777)
+}

--- a/copy/copy_windows.go
+++ b/copy/copy_windows.go
@@ -13,6 +13,10 @@ const (
 	seTakeOwnershipPrivilege = "SeTakeOwnershipPrivilege"
 )
 
+func getUIDGID(fi os.FileInfo) (uid, gid int) {
+	return 0, 0
+}
+
 func getFileSecurityInfo(name string) (*windows.SID, *windows.ACL, error) {
 	secInfo, err := windows.GetNamedSecurityInfo(
 		name, windows.SE_FILE_OBJECT,

--- a/copy/copy_windows.go
+++ b/copy/copy_windows.go
@@ -69,12 +69,23 @@ func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 			return err
 		}
 	}
+
+	if err := c.copyFileTimestamp(fi, name); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
-	// TODO: copy windows specific metadata
+	if c.utime != nil {
+		return Utimes(name, c.utime)
+	}
 
+	if fi.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chtimes(name, fi.ModTime(), fi.ModTime()); err != nil {
+			return errors.Wrap(err, "changing mtime")
+		}
+	}
 	return nil
 }
 

--- a/copy/mkdir_windows.go
+++ b/copy/mkdir_windows.go
@@ -28,6 +28,15 @@ func fixRootDirectory(p string) string {
 }
 
 func Utimes(p string, tm *time.Time) error {
+	info, err := os.Lstat(p)
+	if err != nil {
+		return errors.Wrap(err, "fetching file info")
+	}
+	if tm != nil && info.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chtimes(p, *tm, *tm); err != nil {
+			return errors.Wrap(err, "changing times")
+		}
+	}
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Microsoft/go-winio v0.5.2
-	github.com/containerd/continuity v0.3.0
+	github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8
 	github.com/gogo/protobuf v1.3.2
 	github.com/moby/patternmatcher v0.5.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
-github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
-github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
+github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8 h1:EdSQb65ohzz4jsyPOhxfu3/+c9nnU0euk0otferwl9A=
+github.com/containerd/continuity v0.3.1-0.20230206214859-2a963a2f56e8/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
The c.chowner function was being ignored. This change makes use of the supplied chowner and calls Chown() on the file. If no chowner is specified, we copy over the DACL and owner information from the source.

This change also adds tests and copies timestamps on Windows.

This splits up #143 a bit.