### PR TITLE
Fix follow symlinkResolver on Windows

### DIFF
--- a/followlinks.go
+++ b/followlinks.go
@@ -19,7 +19,7 @@ func FollowLinks(root string, paths []string) ([]string, error) {
 	}
 	res := make([]string, 0, len(r.resolved))
 	for r := range r.resolved {
-		res = append(res, r)
+		res = append(res, filepath.ToSlash(r))
 	}
 	sort.Strings(res)
 	return dedupePaths(res), nil
@@ -31,6 +31,12 @@ type symlinkResolver struct {
 }
 
 func (r *symlinkResolver) append(p string) error {
+	if runtime.GOOS == "windows" && filepath.IsAbs(filepath.FromSlash(p)) {
+		absParts := strings.SplitN(p, ":", 2)
+		if len(absParts) == 2 {
+			p = absParts[1]
+		}
+	}
 	p = filepath.Join(".", p)
 	current := "."
 	for {
@@ -41,7 +47,6 @@ func (r *symlinkResolver) append(p string) error {
 		if err != nil {
 			return err
 		}
-
 		p = ""
 		if len(parts) == 2 {
 			p = parts[1]
@@ -76,7 +81,7 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 	if allowWildcard && containsWildcards(base) {
 		fis, err := os.ReadDir(filepath.Dir(realPath))
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if isNotFound(err) {
 				return nil, nil
 			}
 			return nil, errors.Wrap(err, "readdir")
@@ -96,7 +101,7 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 
 	fi, err := os.Lstat(realPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if isNotFound(err) {
 			return nil, nil
 		}
 		return nil, errors.WithStack(err)
@@ -139,7 +144,7 @@ func dedupePaths(in []string) []string {
 		if s == "." {
 			return nil
 		}
-		if strings.HasPrefix(s, last+string(filepath.Separator)) {
+		if strings.HasPrefix(s, last+"/") {
 			continue
 		}
 		out = append(out, s)

--- a/followlinks_unix.go
+++ b/followlinks_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+// +build !windows
+
+package fsutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func isNotFound(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
+}

--- a/followlinks_windows.go
+++ b/followlinks_windows.go
@@ -1,0 +1,15 @@
+package fsutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+func isNotFound(err error) bool {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, windows.ERROR_INVALID_NAME) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This change handles Windows absolute paths and properly handles IsNotFound errors.

This change also fixes tests on Windows.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>