### PR TITLE
Fix file path separator

### DIFF
--- a/diff_containerd.go
+++ b/diff_containerd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/tonistiigi/fsutil/types"
@@ -110,7 +111,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				if filter != nil {
 					filter(f2.path, &statCopy)
 				}
-				f2copy = &currentPath{path: f2.path, stat: &statCopy}
+				f2copy = &currentPath{path: filepath.FromSlash(f2.path), stat: &statCopy}
 			}
 			k, p := pathChange(f1, f2copy)
 			switch k {
@@ -169,7 +170,6 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 	if upper == nil {
 		return ChangeKindDelete, lower.path
 	}
-
 	switch i := ComparePath(lower.path, upper.path); {
 	case i < 0:
 		// File in lower that is not in upper

--- a/receive.go
+++ b/receive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -190,7 +191,7 @@ func (r *receiver) run(ctx context.Context) error {
 					r.mu.Unlock()
 				}
 				i++
-				cp := &currentPath{path: p.Stat.Path, stat: p.Stat}
+				cp := &currentPath{path: filepath.FromSlash(p.Stat.Path), stat: p.Stat}
 				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}

--- a/receive_test.go
+++ b/receive_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -143,10 +144,10 @@ func TestCopySwitchDirToFile(t *testing.T) {
 
 	dest, err := tmpDir(changeStream([]string{
 		"ADD foo dir",
-		"ADD foo/bar dile data2",
+		"ADD foo/bar file data2",
 	}))
 	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	defer os.RemoveAll(dest)
 
 	copy := func(src, dest string) (*changes, error) {
 		ts := newNotificationBuffer()
@@ -170,8 +171,13 @@ func TestCopySwitchDirToFile(t *testing.T) {
 				NotifyHashed:  chs.HandleChange,
 				ContentHasher: simpleSHA256Hasher,
 				Filter: func(_ string, s *types.Stat) bool {
-					s.Uid = uint32(os.Getuid())
-					s.Gid = uint32(os.Getgid())
+					if runtime.GOOS != "windows" {
+						// On Windows, Getuid() and Getgid() always return -1
+						// See: https://pkg.go.dev/os#Getgid
+						// See: https://pkg.go.dev/os#Geteuid
+						s.Uid = uint32(os.Getuid())
+						s.Gid = uint32(os.Getgid())
+					}
 					return true
 				},
 			})
@@ -196,7 +202,7 @@ func TestCopySwitchDirToFile(t *testing.T) {
 	err = Walk(context.Background(), dest, nil, bufWalk(b))
 	assert.NoError(t, err)
 
-	assert.Equal(t, string(b.Bytes()), `file foo
+	assert.Equal(t, b.String(), `file foo
 `)
 }
 
@@ -239,8 +245,13 @@ func TestCopySimple(t *testing.T) {
 			NotifyHashed:  chs.HandleChange,
 			ContentHasher: simpleSHA256Hasher,
 			Filter: func(p string, s *types.Stat) bool {
-				s.Uid = uint32(os.Getuid())
-				s.Gid = uint32(os.Getgid())
+				if runtime.GOOS != "windows" {
+					// On Windows, Getuid() and Getgid() always return -1
+					// See: https://pkg.go.dev/os#Getgid
+					// See: https://pkg.go.dev/os#Geteuid
+					s.Uid = uint32(os.Getuid())
+					s.Gid = uint32(os.Getgid())
+				}
 				s.ModTime = tm.UnixNano()
 				return true
 			},
@@ -253,7 +264,18 @@ func TestCopySimple(t *testing.T) {
 	err = Walk(context.Background(), dest, nil, bufWalk(b))
 	assert.NoError(t, err)
 
-	assert.Equal(t, string(b.Bytes()), `file foo
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, b.String(), `file foo
+file foo2
+dir zzz
+file zzz\aa
+dir zzz\bb
+dir zzz\bb\cc
+symlink:..\..\ zzz\bb\cc\dd
+file zzz.aa
+`)
+	} else {
+		assert.Equal(t, b.String(), `file foo
 file foo2
 dir zzz
 file zzz/aa
@@ -262,6 +284,7 @@ dir zzz/bb/cc
 symlink:../../ zzz/bb/cc/dd
 file zzz.aa
 `)
+	}
 
 	dt, err := os.ReadFile(filepath.Join(dest, "zzz/aa"))
 	assert.NoError(t, err)
@@ -272,22 +295,33 @@ file zzz.aa
 	assert.Equal(t, "dat2", string(dt))
 
 	fi, err := os.Stat(filepath.Join(dest, "foo2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tm, fi.ModTime())
 
-	h, ok := ts.Hash("zzz/aa")
+	h, ok := ts.Hash(filepath.FromSlash("zzz/aa"))
 	assert.True(t, ok)
-	assert.Equal(t, digest.Digest("sha256:99b6ef96ee0572b5b3a4eb28f00b715d820bfd73836e59cc1565e241f4d1bb2f"), h)
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, digest.Digest("sha256:5da6b6a222dca8d9260384da15378d4389f7e16943e812e08c39759b8514b456"), h)
+	} else {
+		assert.Equal(t, digest.Digest("sha256:99b6ef96ee0572b5b3a4eb28f00b715d820bfd73836e59cc1565e241f4d1bb2f"), h)
+	}
 
 	h, ok = ts.Hash("foo2")
 	assert.True(t, ok)
-	assert.Equal(t, digest.Digest("sha256:dd2529f7749ba45ea55de3b2e10086d6494cc45a94e57650c2882a6a14b4ff32"), h)
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, digest.Digest("sha256:cd83620e5308f6ddb9953a82b2c7450832eac78521dbf067d2882318cabc1311"), h)
+	} else {
+		assert.Equal(t, digest.Digest("sha256:dd2529f7749ba45ea55de3b2e10086d6494cc45a94e57650c2882a6a14b4ff32"), h)
+	}
 
-	h, ok = ts.Hash("zzz/bb/cc/dd")
+	h, ok = ts.Hash(filepath.FromSlash("zzz/bb/cc/dd"))
 	assert.True(t, ok)
-	assert.Equal(t, digest.Digest("sha256:eca07e8f2d09bd574ea2496312e6de1685ef15b8e6a49a534ed9e722bcac8adc"), h)
-
-	k, ok := chs.c["zzz/aa"]
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, digest.Digest("sha256:47dc68d117ae85dc688103d6ba2cee54caabbbcf606e54ca62fda6a3d9deae19"), h)
+	} else {
+		assert.Equal(t, digest.Digest("sha256:eca07e8f2d09bd574ea2496312e6de1685ef15b8e6a49a534ed9e722bcac8adc"), h)
+	}
+	k, ok := chs.c[filepath.FromSlash("zzz/aa")]
 	assert.Equal(t, ok, true)
 	assert.Equal(t, k, ChangeKindAdd)
 
@@ -317,8 +351,13 @@ file zzz.aa
 			NotifyHashed:  chs.HandleChange,
 			ContentHasher: simpleSHA256Hasher,
 			Filter: func(_ string, s *types.Stat) bool {
-				s.Uid = uint32(os.Getuid())
-				s.Gid = uint32(os.Getgid())
+				if runtime.GOOS != "windows" {
+					// On Windows, Getuid() and Getgid() always return -1
+					// See: https://pkg.go.dev/os#Getgid
+					// See: https://pkg.go.dev/os#Geteuid
+					s.Uid = uint32(os.Getuid())
+					s.Gid = uint32(os.Getgid())
+				}
 				s.ModTime = tm.UnixNano()
 				return true
 			},
@@ -330,8 +369,18 @@ file zzz.aa
 	b = &bytes.Buffer{}
 	err = Walk(context.Background(), dest, nil, bufWalk(b))
 	assert.NoError(t, err)
-
-	assert.Equal(t, string(b.Bytes()), `file foo
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, `file foo
+dir zzz
+file zzz\aa
+dir zzz\bb
+dir zzz\bb\cc
+symlink:..\..\ zzz\bb\cc\dd
+file zzz\bb\cc\foo
+file zzz.aa
+`, b.String())
+	} else {
+		assert.Equal(t, `file foo
 dir zzz
 file zzz/aa
 dir zzz/bb
@@ -339,20 +388,27 @@ dir zzz/bb/cc
 symlink:../../ zzz/bb/cc/dd
 file zzz/bb/cc/foo
 file zzz.aa
-`)
+`, b.String())
+	}
 
 	dt, err = os.ReadFile(filepath.Join(dest, "zzz/bb/cc/foo"))
 	assert.NoError(t, err)
 	assert.Equal(t, "data5", string(dt))
 
-	h, ok = ts.Hash("zzz/bb/cc/dd")
+	h, ok = ts.Hash(filepath.FromSlash("zzz/bb/cc/dd"))
 	assert.True(t, ok)
-	assert.Equal(t, digest.Digest("sha256:eca07e8f2d09bd574ea2496312e6de1685ef15b8e6a49a534ed9e722bcac8adc"), h)
-
-	h, ok = ts.Hash("zzz/bb/cc/foo")
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, digest.Digest("sha256:47dc68d117ae85dc688103d6ba2cee54caabbbcf606e54ca62fda6a3d9deae19"), h)
+	} else {
+		assert.Equal(t, digest.Digest("sha256:eca07e8f2d09bd574ea2496312e6de1685ef15b8e6a49a534ed9e722bcac8adc"), h)
+	}
+	h, ok = ts.Hash(filepath.FromSlash("zzz/bb/cc/foo"))
 	assert.True(t, ok)
-	assert.Equal(t, digest.Digest("sha256:cd14a931fc2e123ded338093f2864b173eecdee578bba6ec24d0724272326c3a"), h)
-
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, digest.Digest("sha256:9184a7db8d056ee43838613279db9a7ab02272e50d5e20d253393521bb34aa46"), h)
+	} else {
+		assert.Equal(t, digest.Digest("sha256:cd14a931fc2e123ded338093f2864b173eecdee578bba6ec24d0724272326c3a"), h)
+	}
 	_, ok = ts.Hash("foo2")
 	assert.False(t, ok)
 
@@ -360,15 +416,15 @@ file zzz.aa
 	assert.Equal(t, ok, true)
 	assert.Equal(t, k, ChangeKindDelete)
 
-	k, ok = chs.c["zzz/bb/cc/foo"]
+	k, ok = chs.c[filepath.FromSlash("zzz/bb/cc/foo")]
 	assert.Equal(t, ok, true)
 	assert.Equal(t, k, ChangeKindAdd)
 
-	_, ok = chs.c["zzz/aa"]
+	_, ok = chs.c[filepath.FromSlash("zzz/aa")]
 	assert.Equal(t, ok, false)
 
 	_, ok = chs.c["zzz.aa"]
-	assert.Equal(t, ok, false)
+	assert.Equal(t, false, ok)
 }
 
 func sockPairProto(ctx context.Context) (Stream, Stream) {
@@ -490,8 +546,15 @@ func simpleSHA256Hasher(s *types.Stat) (hash.Hash, error) {
 	// Unlike Linux, on FreeBSD's stat() call returns -1 in st_rdev for regular files
 	ss.Devminor = 0
 	ss.Devmajor = 0
+	if runtime.GOOS == "windows" {
+		// On Windows, Getuid() and Getgid() always return -1
+		// See: https://pkg.go.dev/os#Getgid
+		// See: https://pkg.go.dev/os#Geteuid
+		ss.Uid = 0
+		ss.Gid = 0
+	}
 
-	if os.FileMode(ss.Mode)&os.ModeSymlink != 0 {
+	if os.FileMode(ss.Mode)&os.ModeSymlink != 0 && runtime.GOOS != "windows" {
 		ss.Mode = ss.Mode | 0777
 	}
 
@@ -501,4 +564,51 @@ func simpleSHA256Hasher(s *types.Stat) (hash.Hash, error) {
 	}
 	h.Write(dt)
 	return h, nil
+}
+
+type notificationBuffer struct {
+	items map[string]digest.Digest
+	sync.Mutex
+}
+
+func newNotificationBuffer() *notificationBuffer {
+	nb := &notificationBuffer{
+		items: map[string]digest.Digest{},
+	}
+	return nb
+}
+
+type hashed interface {
+	Digest() digest.Digest
+}
+
+func (nb *notificationBuffer) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err error) (retErr error) {
+	nb.Lock()
+	defer nb.Unlock()
+	if kind == ChangeKindDelete {
+		delete(nb.items, p)
+	} else {
+		h, ok := fi.(hashed)
+		if !ok {
+			return errors.Errorf("invalid FileInfo: %s", p)
+		}
+		nb.items[p] = h.Digest()
+	}
+	return nil
+}
+
+func (nb *notificationBuffer) Hash(p string) (digest.Digest, bool) {
+	nb.Lock()
+	v, ok := nb.items[p]
+	nb.Unlock()
+	return v, ok
+}
+
+// requiresRoot skips tests that require root
+func requiresRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root")
+		return
+	}
 }

--- a/stat.go
+++ b/stat.go
@@ -19,7 +19,7 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 	relpath = filepath.ToSlash(relpath)
 
 	stat := &types.Stat{
-		Path:    relpath,
+		Path:    filepath.FromSlash(relpath),
 		Mode:    uint32(fi.Mode()),
 		ModTime: fi.ModTime().UnixNano(),
 	}

--- a/validator.go
+++ b/validator.go
@@ -1,9 +1,9 @@
 package fsutil
 
 import (
+	"fmt"
 	"os"
-	"path"
-	"runtime"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -28,21 +28,20 @@ func (v *Validator) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err 
 	if v.parentDirs == nil {
 		v.parentDirs = make([]parent, 1, 10)
 	}
-	if runtime.GOOS == "windows" {
-		p = strings.Replace(p, "\\", "", -1)
-	}
-	if p != path.Clean(p) {
+
+	if p != filepath.Clean(p) {
 		return errors.WithStack(&os.PathError{Path: p, Err: syscall.EINVAL, Op: "unclean path"})
 	}
-	if path.IsAbs(p) {
+
+	if filepath.IsAbs(p) {
 		return errors.WithStack(&os.PathError{Path: p, Err: syscall.EINVAL, Op: "absolute path"})
 	}
-	dir := path.Dir(p)
-	base := path.Base(p)
+	dir := filepath.Dir(p)
+	base := filepath.Base(p)
 	if dir == "." {
 		dir = ""
 	}
-	if dir == ".." || strings.HasPrefix(p, "../") {
+	if dir == ".." || strings.HasPrefix(p, fmt.Sprintf("..%c", os.PathSeparator)) {
 		return errors.WithStack(&os.PathError{Path: p, Err: syscall.EINVAL, Op: "escape check"})
 	}
 
@@ -56,12 +55,12 @@ func (v *Validator) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err 
 	}
 
 	if dir != v.parentDirs[len(v.parentDirs)-1].dir || v.parentDirs[i].last >= base {
-		return errors.Errorf("changes out of order: %q %q", p, path.Join(v.parentDirs[i].dir, v.parentDirs[i].last))
+		return errors.Errorf("changes out of order: %q %q", p, filepath.Join(v.parentDirs[i].dir, v.parentDirs[i].last))
 	}
 	v.parentDirs[i].last = base
 	if kind != ChangeKindDelete && fi.IsDir() {
 		v.parentDirs = append(v.parentDirs, parent{
-			dir:  path.Join(dir, base),
+			dir:  filepath.Join(dir, base),
 			last: "",
 		})
 	}
@@ -76,7 +75,7 @@ func ComparePath(p1, p2 string) int {
 		switch {
 		case p1[i] == p2[i]:
 			continue
-		case p2[i] != '/' && p1[i] < p2[i] || p1[i] == '/':
+		case p2[i] != os.PathSeparator && p1[i] < p2[i] || p1[i] == os.PathSeparator:
 			return -1
 		default:
 			return 1

--- a/validator_test.go
+++ b/validator_test.go
@@ -3,6 +3,7 @@ package fsutil
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -210,7 +211,7 @@ func parseChange(str string) *change {
 	default:
 		panic(errStr)
 	}
-	c.path = f[1]
+	c.path = filepath.FromSlash(f[1])
 	st := &types.Stat{}
 	switch f[2] {
 	case "file":


### PR DESCRIPTION
This change switches to filepath instead of path and calls filepath.FromSlash() where appropriate.

This change also fixes some tests on Windows.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>