### PR TITLE
Use RunWithPrivileges

### DIFF
--- a/copy/mkdir_windows.go
+++ b/copy/mkdir_windows.go
@@ -54,16 +54,6 @@ func Chown(p string, old *User, fn Chowner) error {
 		userSIDstring = containerAdministratorSidString
 
 	}
-	// Copy file ownership and ACL
-	// We need SeRestorePrivilege and SeTakeOwnershipPrivilege in order
-	// to restore security info on a file, especially if we're trying to
-	// apply security info which includes SIDs not necessarily present on
-	// the host.
-	privileges := []string{winio.SeRestorePrivilege, seTakeOwnershipPrivilege}
-	if err := winio.EnableProcessPrivileges(privileges); err != nil {
-		return err
-	}
-	defer winio.DisableProcessPrivileges(privileges)
 
 	sidPtr, err := syscall.UTF16PtrFromString(userSIDstring)
 	if err != nil {
@@ -90,13 +80,22 @@ func Chown(p string, old *User, fn Chowner) error {
 		return fmt.Errorf("adding acls: %w", err)
 	}
 
-	if err := windows.SetNamedSecurityInfo(
-		p, windows.SE_FILE_OBJECT,
-		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
-		userSID, nil, newAcl, nil); err != nil {
+	// Copy file ownership and ACL
+	// We need SeRestorePrivilege and SeTakeOwnershipPrivilege in order
+	// to restore security info on a file, especially if we're trying to
+	// apply security info which includes SIDs not necessarily present on
+	// the host.
+	privileges := []string{winio.SeRestorePrivilege, seTakeOwnershipPrivilege}
+	err = winio.RunWithPrivileges(privileges, func() error {
+		if err := windows.SetNamedSecurityInfo(
+			p, windows.SE_FILE_OBJECT,
+			windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+			userSID, nil, newAcl, nil); err != nil {
 
-		return err
-	}
+			return err
+		}
+		return nil
+	})
 
-	return nil
+	return err
 }


### PR DESCRIPTION
The ```EnableProcessPrivileges()``` function will enable a certain set of privileges for the entire process. I am unsure if enabling/disabling privileges is tracked with some sort of reference counting, but if it's not, when we release those privileges, we disable them for the entire process. This means that if some other go routine requires them, we may end up with undesirable results.

The ```RunWithPrivileges()``` function locks the thread in which the function runs, and enables those privileges only in that thread.