### PR TITLE
handle mkdir race for diskwriter

### DIFF
--- a/diskwriter.go
+++ b/diskwriter.go
@@ -162,6 +162,10 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 	switch {
 	case fi.IsDir():
 		if err := os.Mkdir(newPath, fi.Mode()); err != nil {
+			if errors.Is(err, syscall.EEXIST) {
+				// we saw a race to create this directory, so try again
+				return dw.HandleChange(kind, p, fi, nil)
+			}
 			return errors.Wrapf(err, "failed to create dir %s", newPath)
 		}
 		dw.dirModTimes[destPath] = statCopy.ModTime


### PR DESCRIPTION
If using the diskwriter hanlders in parallel we might see a common directory being created in parallel, only one will win.  This allows us to gracefully retry/re-evaluate when we get a syscall.EEXIST error on the mkdir instead of returning an error.