### PR TITLE
ci: update actions to fix warnings and split jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,36 +16,68 @@ on:
       - master
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - lint
+          - validate-gomod
+          - validate-shfmt
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Run
+        uses: docker/bake-action@v3
+        with:
+          targets: ${{ matrix.target }}
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - build
+          - cross
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Run
+        uses: docker/bake-action@v3
+        with:
+          targets: ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        GO_VERSION: ["1.19", "1.20"]
+        go_version:
+          - "1.19"
+          - "1.20"
     env:
-      GO_VERSION: ${{ matrix.GO_VERSION }}
+      GO_VERSION: ${{ matrix.go_version }}
     steps:
       -
-         name: Set up Docker Buildx
-         uses: docker/setup-buildx-action@v1
-      -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
-        name: Build
-        run: |
-          docker buildx bake
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       -
         name: Test
-        run: |
-          docker buildx bake test
-      -
-        name: Linters
-        run: |
-          docker buildx bake lint validate-gomod validate-shfmt
-      -
-        name: Cross
-        run: |
-          docker buildx bake cross
+        uses: docker/bake-action@v3
+        with:
+          targets: test
 
   test-macos:
     runs-on: macos-latest
@@ -58,20 +90,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-      -
-        name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go }}-
       -
         name: Test
         run: |
@@ -85,10 +109,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Cache Vagrant boxes
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ hashFiles('hack/Vagrantfile.freebsd13') }}


### PR DESCRIPTION
We got a bunch of warnings in CI:

![image](https://github.com/tonistiigi/fsutil/assets/1951866/049a842d-f40f-4aca-91a3-dcfbd84a09fb)

This PR updates actions to latest stable to fix this issue and also split jobs to reduce build time a bit more.