### PR TITLE
fs: split out include/exclude into new FilterFS

### DIFF
--- a/cmd/send/send.go
+++ b/cmd/send/send.go
@@ -18,7 +18,11 @@ func main() {
 	ctx := context.Background()
 	s := util.NewProtoStream(ctx, os.Stdin, os.Stdout)
 
-	if err := fsutil.Send(ctx, s, fsutil.NewFS(flag.Args()[0], nil), nil); err != nil {
+	fs, err := fsutil.NewFS(flag.Args()[0])
+	if err != nil {
+		panic(err)
+	}
+	if err := fsutil.Send(ctx, s, fs, nil); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/walk/walk.go
+++ b/cmd/walk/walk.go
@@ -25,7 +25,7 @@ func main() {
 		excludes = strings.Split(string(dt), "\n")
 	}
 
-	if err := fsutil.Walk(context.Background(), flag.Args()[0], &fsutil.WalkOpt{
+	if err := fsutil.Walk(context.Background(), flag.Args()[0], &fsutil.FilterOpt{
 		ExcludePatterns: excludes,
 	}, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {

--- a/filter.go
+++ b/filter.go
@@ -2,19 +2,19 @@ package fsutil
 
 import (
 	"context"
+	"io"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/moby/patternmatcher"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
-type WalkOpt struct {
+type FilterOpt struct {
 	IncludePatterns []string
 	ExcludePatterns []string
 	// FollowPaths contains symlinks that are resolved into include patterns
@@ -43,31 +43,36 @@ const (
 	MapResultSkipDir
 )
 
-func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) error {
-	root, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return errors.WithStack(&os.PathError{Op: "resolve", Path: root, Err: err})
-	}
-	rootFI, err := os.Stat(root)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if !rootFI.IsDir() {
-		return errors.WithStack(&os.PathError{Op: "walk", Path: root, Err: syscall.ENOTDIR})
-	}
+type filterFS struct {
+	fs  FS
+	opt *FilterOpt
+}
 
+func NewFilterFS(fs FS, opt *FilterOpt) FS {
+	if opt == nil {
+		return fs
+	}
+	return &filterFS{fs, opt}
+}
+
+func (fs *filterFS) Open(p string) (io.ReadCloser, error) {
+	return fs.fs.Open(p)
+}
+
+func (fs *filterFS) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
 	var (
 		includePatterns []string
 		includeMatcher  *patternmatcher.PatternMatcher
 		excludeMatcher  *patternmatcher.PatternMatcher
+		err             error
 	)
 
-	if opt != nil && opt.IncludePatterns != nil {
-		includePatterns = make([]string, len(opt.IncludePatterns))
-		copy(includePatterns, opt.IncludePatterns)
+	if fs.opt != nil && fs.opt.IncludePatterns != nil {
+		includePatterns = make([]string, len(fs.opt.IncludePatterns))
+		copy(includePatterns, fs.opt.IncludePatterns)
 	}
-	if opt != nil && opt.FollowPaths != nil {
-		targets, err := FollowLinks(p, opt.FollowPaths)
+	if fs.opt != nil && fs.opt.FollowPaths != nil {
+		targets, err := FollowLinks(fs.fs, fs.opt.FollowPaths)
 		if err != nil {
 			return err
 		}
@@ -86,7 +91,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	if len(includePatterns) != 0 {
 		includeMatcher, err = patternmatcher.New(includePatterns)
 		if err != nil {
-			return errors.Wrapf(err, "invalid includepatterns: %s", opt.IncludePatterns)
+			return errors.Wrapf(err, "invalid includepatterns: %s", fs.opt.IncludePatterns)
 		}
 
 		for _, p := range includeMatcher.Patterns() {
@@ -99,10 +104,10 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	}
 
 	onlyPrefixExcludeExceptions := true
-	if opt != nil && opt.ExcludePatterns != nil {
-		excludeMatcher, err = patternmatcher.New(opt.ExcludePatterns)
+	if fs.opt != nil && fs.opt.ExcludePatterns != nil {
+		excludeMatcher, err = patternmatcher.New(fs.opt.ExcludePatterns)
 		if err != nil {
-			return errors.Wrapf(err, "invalid excludepatterns: %s", opt.ExcludePatterns)
+			return errors.Wrapf(err, "invalid excludepatterns: %s", fs.opt.ExcludePatterns)
 		}
 
 		for _, p := range excludeMatcher.Patterns() {
@@ -114,9 +119,7 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	}
 
 	type visitedDir struct {
-		fi               os.FileInfo
-		path             string
-		origpath         string
+		entry            gofs.DirEntry
 		pathWithSep      string
 		includeMatchInfo patternmatcher.MatchInfo
 		excludeMatchInfo patternmatcher.MatchInfo
@@ -126,28 +129,16 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 	// used only for include/exclude handling
 	var parentDirs []visitedDir
 
-	seenFiles := make(map[uint64]string)
-	return filepath.WalkDir(root, func(path string, dirEntry gofs.DirEntry, walkErr error) (retErr error) {
+	return fs.fs.Walk(ctx, target, func(path string, dirEntry gofs.DirEntry, walkErr error) (retErr error) {
 		defer func() {
 			if retErr != nil && isNotExist(retErr) {
 				retErr = filepath.SkipDir
 			}
 		}()
 
-		origpath := path
-		path, err = filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		// Skip root
-		if path == "." {
-			return nil
-		}
-
 		var (
 			dir   visitedDir
 			isDir bool
-			fi    gofs.FileInfo
 		)
 		if dirEntry != nil {
 			isDir = dirEntry.IsDir()
@@ -163,15 +154,8 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 			}
 
 			if isDir {
-				fi, err = dirEntry.Info()
-				if err != nil {
-					return err
-				}
-
 				dir = visitedDir{
-					fi:          fi,
-					path:        path,
-					origpath:    origpath,
+					entry:       dirEntry,
 					pathWithSep: path + string(filepath.Separator),
 				}
 			}
@@ -275,25 +259,21 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 
 		dir.calledFn = true
 
-		// The FileInfo might have already been read further up.
-		if fi == nil {
-			fi, err = dirEntry.Info()
-			if err != nil {
-				return err
-			}
-		}
-
-		stat, err := mkstat(origpath, path, fi, seenFiles)
+		fi, err := dirEntry.Info()
 		if err != nil {
 			return err
+		}
+		stat, ok := fi.Sys().(*types.Stat)
+		if !ok {
+			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if opt != nil && opt.Map != nil {
-				result := opt.Map(stat.Path, stat)
+			if fs.opt != nil && fs.opt.Map != nil {
+				result := fs.opt.Map(stat.Path, stat)
 				if result == MapResultSkipDir {
 					return filepath.SkipDir
 				} else if result == MapResultExclude {
@@ -304,9 +284,13 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 				if parentDir.calledFn {
 					continue
 				}
-				parentStat, err := mkstat(parentDir.origpath, parentDir.path, parentDir.fi, seenFiles)
+				parentFi, err := parentDir.entry.Info()
 				if err != nil {
 					return err
+				}
+				parentStat, ok := parentFi.Sys().(*types.Stat)
+				if !ok {
+					return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 				}
 
 				select {
@@ -314,24 +298,50 @@ func Walk(ctx context.Context, p string, opt *WalkOpt, fn filepath.WalkFunc) err
 					return ctx.Err()
 				default:
 				}
-				if opt != nil && opt.Map != nil {
-					result := opt.Map(parentStat.Path, parentStat)
+				if fs.opt != nil && fs.opt.Map != nil {
+					result := fs.opt.Map(parentStat.Path, parentStat)
 					if result == MapResultSkipDir || result == MapResultExclude {
 						continue
 					}
 				}
 
-				if err := fn(parentStat.Path, &StatInfo{parentStat}, nil); err != nil {
+				if err := fn(parentStat.Path, &DirEntryInfo{Stat: parentStat}, nil); err != nil {
 					return err
 				}
 				parentDirs[i].calledFn = true
 			}
-			if err := fn(stat.Path, &StatInfo{stat}, nil); err != nil {
+			if err := fn(stat.Path, &DirEntryInfo{Stat: stat}, nil); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+func Walk(ctx context.Context, p string, opt *FilterOpt, fn filepath.WalkFunc) error {
+	f, err := NewFS(p)
+	if err != nil {
+		return err
+	}
+	return NewFilterFS(f, opt).Walk(ctx, "/", func(path string, d gofs.DirEntry, err error) error {
+		var info gofs.FileInfo
+		if d != nil {
+			var err2 error
+			info, err2 = d.Info()
+			if err == nil {
+				err = err2
+			}
+		}
+		return fn(path, info, err)
+	})
+}
+
+func WalkDir(ctx context.Context, p string, opt *FilterOpt, fn gofs.WalkDirFunc) error {
+	f, err := NewFS(p)
+	if err != nil {
+		return err
+	}
+	return NewFilterFS(f, opt).Walk(ctx, "/", fn)
 }
 
 func patternWithoutTrailingGlob(p *patternmatcher.Pattern) string {
@@ -342,29 +352,6 @@ func patternWithoutTrailingGlob(p *patternmatcher.Pattern) string {
 	patStr = strings.TrimSuffix(patStr, string(filepath.Separator)+"**")
 	patStr = strings.TrimSuffix(patStr, string(filepath.Separator)+"*")
 	return patStr
-}
-
-type StatInfo struct {
-	*types.Stat
-}
-
-func (s *StatInfo) Name() string {
-	return filepath.Base(s.Stat.Path)
-}
-func (s *StatInfo) Size() int64 {
-	return s.Stat.Size_
-}
-func (s *StatInfo) Mode() os.FileMode {
-	return os.FileMode(s.Stat.Mode)
-}
-func (s *StatInfo) ModTime() time.Time {
-	return time.Unix(s.Stat.ModTime/1e9, s.Stat.ModTime%1e9)
-}
-func (s *StatInfo) IsDir() bool {
-	return s.Mode().IsDir()
-}
-func (s *StatInfo) Sys() interface{} {
-	return s.Stat
 }
 
 func isNotExist(err error) bool {

--- a/followlinks.go
+++ b/followlinks.go
@@ -1,17 +1,21 @@
 package fsutil
 
 import (
+	"context"
+	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	strings "strings"
+	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/tonistiigi/fsutil/types"
 )
 
-func FollowLinks(root string, paths []string) ([]string, error) {
-	r := &symlinkResolver{root: root, resolved: map[string]struct{}{}}
+func FollowLinks(fs FS, paths []string) ([]string, error) {
+	r := &symlinkResolver{fs: fs, resolved: map[string]struct{}{}}
 	for _, p := range paths {
 		if err := r.append(p); err != nil {
 			return nil, err
@@ -26,7 +30,7 @@ func FollowLinks(root string, paths []string) ([]string, error) {
 }
 
 type symlinkResolver struct {
-	root     string
+	fs       FS
 	resolved map[string]struct{}
 }
 
@@ -76,10 +80,9 @@ func (r *symlinkResolver) append(p string) error {
 }
 
 func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, error) {
-	realPath := filepath.Join(r.root, p)
 	base := filepath.Base(p)
 	if allowWildcard && containsWildcards(base) {
-		fis, err := os.ReadDir(filepath.Dir(realPath))
+		fis, err := readDir(r.fs, filepath.Dir(p))
 		if err != nil {
 			if isNotFound(err) {
 				return nil, nil
@@ -99,27 +102,106 @@ func (r *symlinkResolver) readSymlink(p string, allowWildcard bool) ([]string, e
 		return out, nil
 	}
 
-	fi, err := os.Lstat(realPath)
+	entry, err := statFile(r.fs, p)
 	if err != nil {
 		if isNotFound(err) {
 			return nil, nil
 		}
 		return nil, errors.WithStack(err)
 	}
-	if fi.Mode()&os.ModeSymlink == 0 {
+	if entry == nil {
 		return nil, nil
 	}
-	link, err := os.Readlink(realPath)
+	if entry.Type()&os.ModeSymlink == 0 {
+		return nil, nil
+	}
+
+	fi, err := entry.Info()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	link = filepath.Clean(link)
+	stat, ok := fi.Sys().(*types.Stat)
+	if !ok {
+		return nil, errors.WithStack(&os.PathError{Path: p, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
+	}
+
+	link := filepath.Clean(stat.Linkname)
 	if filepath.IsAbs(link) {
 		return []string{link}, nil
 	}
 	return []string{
 		filepath.Join(string(filepath.Separator), filepath.Join(filepath.Dir(p), link)),
 	}, nil
+}
+
+func statFile(fs FS, root string) (os.DirEntry, error) {
+	var out os.DirEntry
+
+	root = filepath.Clean(root)
+	if root == "/" || root == "." {
+		return nil, nil
+	}
+
+	err := fs.Walk(context.TODO(), root, func(p string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p != root {
+			return errors.Errorf("expected single entry %q but got %q", root, p)
+		}
+		out = entry
+		if entry.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, errors.Wrapf(os.ErrNotExist, "readFile %s", root)
+	}
+	return out, nil
+}
+
+func readDir(fs FS, root string) ([]os.DirEntry, error) {
+	var out []os.DirEntry
+
+	root = filepath.Clean(root)
+	if root == "/" || root == "." {
+		root = "."
+		out = make([]gofs.DirEntry, 0)
+	}
+
+	err := fs.Walk(context.TODO(), root, func(p string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			if !entry.IsDir() {
+				return errors.WithStack(&os.PathError{Op: "walk", Path: root, Err: syscall.ENOTDIR})
+			}
+			out = make([]gofs.DirEntry, 0)
+			return nil
+		}
+		if out == nil {
+			return errors.Errorf("expected to read parent entry %q before child %q", root, p)
+		}
+		out = append(out, entry)
+		if entry.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil && root != "." {
+		return nil, errors.Wrapf(os.ErrNotExist, "readDir %s", root)
+	}
+	return out, nil
 }
 
 func containsWildcards(name string) bool {

--- a/followlinks_test.go
+++ b/followlinks_test.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 func TestFollowLinks(t *testing.T) {
 	tmpDir := t.TempDir()
-
 	apply := fstest.Apply(
 		fstest.CreateDir("dir", 0700),
 		fstest.CreateFile("dir/foo", []byte("contents"), 0600),
@@ -20,10 +20,11 @@ func TestFollowLinks(t *testing.T) {
 		fstest.CreateFile("bar", nil, 0600),
 		fstest.CreateFile("baz", nil, 0600),
 	)
-
 	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"l2", "bar"})
+	out, err := FollowLinks(tmpfs, []string{"l2", "bar"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"bar", "dir/foo", "dir/l1", "l2"})
@@ -31,28 +32,28 @@ func TestFollowLinks(t *testing.T) {
 
 func TestFollowLinksLoop(t *testing.T) {
 	tmpDir := t.TempDir()
-
 	apply := fstest.Apply(
 		fstest.Symlink("l1", "l1"),
 		fstest.Symlink("l2", "l3"),
 		fstest.Symlink("l3", "l2"),
 	)
 	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"l1", "l3"})
+	out, err := FollowLinks(tmpfs, []string{"l1", "l3"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"l1", "l2", "l3"})
 }
 
 func TestFollowLinksAbsolute(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	abslutePathForBaz := "/foo/bar/baz"
 	if runtime.GOOS == "windows" {
 		abslutePathForBaz = "C:/foo/bar/baz"
 	}
 
+	tmpDir := t.TempDir()
 	apply := fstest.Apply(
 		fstest.CreateDir("dir", 0700),
 		fstest.Symlink(abslutePathForBaz, "dir/l1"),
@@ -61,15 +62,16 @@ func TestFollowLinksAbsolute(t *testing.T) {
 		fstest.CreateFile("baz", nil, 0600),
 	)
 	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"dir/l1"})
+	out, err := FollowLinks(tmpfs, []string{"dir/l1"})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"baz", "dir/l1", "foo/bar"}, out)
 
 	// same but a link outside root
 	tmpDir = t.TempDir()
-
 	apply = fstest.Apply(
 		fstest.CreateDir("dir", 0700),
 		fstest.Symlink(abslutePathForBaz, "dir/l1"),
@@ -78,8 +80,10 @@ func TestFollowLinksAbsolute(t *testing.T) {
 		fstest.CreateFile("baz", nil, 0600),
 	)
 	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err = NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err = FollowLinks(tmpDir, []string{"dir/l1"})
+	out, err = FollowLinks(tmpfs, []string{"dir/l1"})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"baz", "dir/l1", "foo/bar"}, out)
@@ -87,19 +91,21 @@ func TestFollowLinksAbsolute(t *testing.T) {
 
 func TestFollowLinksNotExists(t *testing.T) {
 	tmpDir := t.TempDir()
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"foo/bar/baz", "bar/baz"})
+	out, err := FollowLinks(tmpfs, []string{"foo/bar/baz", "bar/baz"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"bar/baz", "foo/bar/baz"})
 
 	// root works fine with empty directory
-	out, err = FollowLinks(tmpDir, []string{"."})
+	out, err = FollowLinks(tmpfs, []string{"."})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string(nil))
 
-	out, err = FollowLinks(tmpDir, []string{"f*/foo/t*"})
+	out, err = FollowLinks(tmpfs, []string{"f*/foo/t*"})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"f*/foo/t*"}, out)
@@ -107,8 +113,10 @@ func TestFollowLinksNotExists(t *testing.T) {
 
 func TestFollowLinksNormalized(t *testing.T) {
 	tmpDir := t.TempDir()
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"foo/bar/baz", "foo/bar"})
+	out, err := FollowLinks(tmpfs, []string{"foo/bar/baz", "foo/bar"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"foo/bar"})
@@ -127,25 +135,24 @@ func TestFollowLinksNormalized(t *testing.T) {
 	)
 	require.NoError(t, apply.Apply(tmpDir))
 
-	out, err = FollowLinks(tmpDir, []string{"dir/l1", "foo/bar"})
+	out, err = FollowLinks(tmpfs, []string{"dir/l1", "foo/bar"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"dir/l1", "foo"})
 
-	out, err = FollowLinks(tmpDir, []string{"dir/l2", "foo", "foo/bar"})
+	out, err = FollowLinks(tmpfs, []string{"dir/l2", "foo", "foo/bar"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string(nil))
 }
 
 func TestFollowLinksWildcard(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	absolutePathForFoo := "/foo"
 	if runtime.GOOS == "windows" {
 		absolutePathForFoo = "C:/foo"
 	}
 
+	tmpDir := t.TempDir()
 	apply := fstest.Apply(
 		fstest.CreateDir("dir", 0700),
 		fstest.CreateDir("foo", 0700),
@@ -158,19 +165,89 @@ func TestFollowLinksWildcard(t *testing.T) {
 		fstest.CreateFile("baz", nil, 0600),
 	)
 	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
 
-	out, err := FollowLinks(tmpDir, []string{"dir/l*"})
+	out, err := FollowLinks(tmpfs, []string{"dir/l*"})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"baz", "dir/l*", "foo/bar1", "foo/bar2"}, out)
 
-	out, err = FollowLinks(tmpDir, []string{"dir"})
+	out, err = FollowLinks(tmpfs, []string{"dir"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"dir"})
 
-	out, err = FollowLinks(tmpDir, []string{"dir", "dir/*link"})
+	out, err = FollowLinks(tmpfs, []string{"dir", "dir/*link"})
 	require.NoError(t, err)
 
 	require.Equal(t, out, []string{"dir", "foo/bar3"})
+}
+
+func TestInternalReadFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/foo1", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
+
+	entry, err := statFile(tmpfs, "/")
+	require.NoError(t, err)
+	require.Nil(t, entry)
+	entry, err = statFile(tmpfs, "")
+	require.NoError(t, err)
+	require.Nil(t, entry)
+
+	entry, err = statFile(tmpfs, "dir")
+	require.NoError(t, err)
+	require.Equal(t, "dir", entry.Name())
+	require.True(t, entry.Type().IsDir())
+	entry, err = statFile(tmpfs, "dir/foo1")
+	require.NoError(t, err)
+	require.Equal(t, "foo1", entry.Name())
+	require.False(t, entry.Type().IsDir())
+
+	entry, err = statFile(tmpfs, "dir/foo2")
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Nil(t, entry)
+	entry, err = statFile(tmpfs, "dir/x/y/z")
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Nil(t, entry)
+}
+
+func TestInternalReadDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/foo1", nil, 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
+
+	entries, err := readDir(tmpfs, "/")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "dir", entries[0].Name())
+	require.True(t, entries[0].IsDir())
+
+	entries, err = readDir(tmpfs, "dir")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "foo1", entries[0].Name())
+
+	entries, err = readDir(tmpfs, "dir2")
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Empty(t, entries)
+
+	entries, err = readDir(tmpfs, "dir/foo1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Empty(t, entries)
 }

--- a/fs.go
+++ b/fs.go
@@ -3,36 +3,85 @@ package fsutil
 import (
 	"context"
 	"io"
+	gofs "io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
 type FS interface {
-	Walk(context.Context, filepath.WalkFunc) error
+	Walk(context.Context, string, gofs.WalkDirFunc) error
 	Open(string) (io.ReadCloser, error)
 }
 
-func NewFS(root string, opt *WalkOpt) FS {
+func NewFS(root string) (FS, error) {
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, errors.WithStack(&os.PathError{Op: "resolve", Path: root, Err: err})
+	}
+	fi, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.IsDir() {
+		return nil, errors.WithStack(&os.PathError{Op: "stat", Path: root, Err: syscall.ENOTDIR})
+	}
+
 	return &fs{
 		root: root,
-		opt:  opt,
-	}
+	}, nil
 }
 
 type fs struct {
 	root string
-	opt  *WalkOpt
 }
 
-func (fs *fs) Walk(ctx context.Context, fn filepath.WalkFunc) error {
-	return Walk(ctx, fs.root, fs.opt, fn)
+func (fs *fs) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
+	seenFiles := make(map[uint64]string)
+	return filepath.WalkDir(filepath.Join(fs.root, target), func(path string, dirEntry gofs.DirEntry, walkErr error) (retErr error) {
+		defer func() {
+			if retErr != nil && isNotExist(retErr) {
+				retErr = filepath.SkipDir
+			}
+		}()
+
+		origpath := path
+		path, err := filepath.Rel(fs.root, path)
+		if err != nil {
+			return err
+		}
+		// Skip root
+		if path == "." {
+			return nil
+		}
+
+		var entry gofs.DirEntry
+		if dirEntry != nil {
+			entry = &DirEntryInfo{
+				path:      path,
+				origpath:  origpath,
+				entry:     dirEntry,
+				seenFiles: seenFiles,
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := fn(path, entry, walkErr); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (fs *fs) Open(p string) (io.ReadCloser, error) {
@@ -67,16 +116,31 @@ type subDirFS struct {
 	dirs []Dir
 }
 
-func (fs *subDirFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
+func (fs *subDirFS) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
+	first, rest, _ := strings.Cut(target, string(filepath.Separator))
+
 	for _, d := range fs.dirs {
-		fi := &StatInfo{Stat: &d.Stat}
+		if first != "" && first != d.Stat.Path {
+			continue
+		}
+
+		fi := &StatInfo{&d.Stat}
 		if !fi.IsDir() {
 			return errors.WithStack(&os.PathError{Path: d.Stat.Path, Err: syscall.ENOTDIR, Op: "walk subdir"})
 		}
-		if err := fn(d.Stat.Path, fi, nil); err != nil {
+		dStat := d.Stat
+		if err := fn(d.Stat.Path, &DirEntryInfo{Stat: &dStat}, nil); err != nil {
 			return err
 		}
-		if err := d.FS.Walk(ctx, func(p string, fi os.FileInfo, err error) error {
+		if err := d.FS.Walk(ctx, rest, func(p string, entry gofs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			fi, err := entry.Info()
+			if err != nil {
+				return err
+			}
 			stat, ok := fi.Sys().(*types.Stat)
 			if !ok {
 				return errors.WithStack(&os.PathError{Path: d.Stat.Path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
@@ -91,7 +155,7 @@ func (fs *subDirFS) Walk(ctx context.Context, fn filepath.WalkFunc) error {
 					stat.Linkname = path.Join(d.Stat.Path, stat.Linkname)
 				}
 			}
-			return fn(filepath.Join(d.Stat.Path, p), &StatInfo{stat}, nil)
+			return fn(filepath.Join(d.Stat.Path, p), &DirEntryInfo{Stat: stat}, nil)
 		}); err != nil {
 			return err
 		}
@@ -116,4 +180,71 @@ type emptyReader struct {
 
 func (*emptyReader) Read([]byte) (int, error) {
 	return 0, io.EOF
+}
+
+type StatInfo struct {
+	*types.Stat
+}
+
+func (s *StatInfo) Name() string {
+	return filepath.Base(s.Stat.Path)
+}
+func (s *StatInfo) Size() int64 {
+	return s.Stat.Size_
+}
+func (s *StatInfo) Mode() os.FileMode {
+	return os.FileMode(s.Stat.Mode)
+}
+func (s *StatInfo) ModTime() time.Time {
+	return time.Unix(s.Stat.ModTime/1e9, s.Stat.ModTime%1e9)
+}
+func (s *StatInfo) IsDir() bool {
+	return s.Mode().IsDir()
+}
+func (s *StatInfo) Sys() interface{} {
+	return s.Stat
+}
+
+type DirEntryInfo struct {
+	*types.Stat
+
+	entry     gofs.DirEntry
+	path      string
+	origpath  string
+	seenFiles map[uint64]string
+}
+
+func (s *DirEntryInfo) Name() string {
+	if s.Stat != nil {
+		return filepath.Base(s.Stat.Path)
+	}
+	return s.entry.Name()
+}
+func (s *DirEntryInfo) IsDir() bool {
+	if s.Stat != nil {
+		return s.Stat.IsDir()
+	}
+	return s.entry.IsDir()
+}
+func (s *DirEntryInfo) Type() gofs.FileMode {
+	if s.Stat != nil {
+		return gofs.FileMode(s.Stat.Mode)
+	}
+	return s.entry.Type()
+}
+func (s *DirEntryInfo) Info() (gofs.FileInfo, error) {
+	if s.Stat == nil {
+		fi, err := s.entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		stat, err := mkstat(s.origpath, s.path, fi, s.seenFiles)
+		if err != nil {
+			return nil, err
+		}
+		s.Stat = stat
+	}
+
+	st := *s.Stat
+	return &StatInfo{&st}, nil
 }

--- a/fs.go
+++ b/fs.go
@@ -21,6 +21,7 @@ type FS interface {
 	Open(string) (io.ReadCloser, error)
 }
 
+// NewFS creates a new FS from a root directory on the host filesystem.
 func NewFS(root string) (FS, error) {
 	root, err := filepath.EvalSymlinks(root)
 	if err != nil {

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,0 +1,105 @@
+package fsutil
+
+import (
+	"context"
+	gofs "io/fs"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func TestWalk(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/foo", []byte("contents"), 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	f, err := NewFS(tmpDir)
+	require.NoError(t, err)
+	paths := []string{}
+	files := []gofs.DirEntry{}
+	err = f.Walk(context.TODO(), "", func(path string, entry gofs.DirEntry, err error) error {
+		require.NoError(t, err)
+		paths = append(paths, path)
+		files = append(files, entry)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, paths, []string{"dir", "dir/foo"})
+	require.Len(t, files, 2)
+	require.Equal(t, "dir", files[0].Name())
+	require.Equal(t, "foo", files[1].Name())
+
+	fis := []gofs.FileInfo{}
+	for _, f := range files {
+		fi, err := f.Info()
+		require.NoError(t, err)
+		fis = append(fis, fi)
+	}
+	require.Equal(t, "dir", fis[0].Name())
+	require.Equal(t, "foo", fis[1].Name())
+
+	require.Equal(t, len("contents"), int(fis[1].Size()))
+
+	require.Equal(t, "dir", fis[0].(*StatInfo).Path)
+	require.Equal(t, "dir/foo", fis[1].(*StatInfo).Path)
+}
+
+func TestWalkDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/foo", []byte("contents"), 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+	tmpfs, err := NewFS(tmpDir)
+	require.NoError(t, err)
+
+	tmpDir2 := t.TempDir()
+	apply = fstest.Apply(
+		fstest.CreateDir("dir", 0700),
+		fstest.CreateFile("dir/bar", []byte("contents2"), 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir2))
+	tmpfs2, err := NewFS(tmpDir2)
+	require.NoError(t, err)
+
+	f, err := SubDirFS([]Dir{
+		{
+			Stat: types.Stat{
+				Mode: uint32(os.ModeDir | 0755),
+				Path: "1",
+			},
+			FS: tmpfs,
+		},
+		{
+			Stat: types.Stat{
+				Mode: uint32(os.ModeDir | 0755),
+				Path: "2",
+			},
+			FS: tmpfs2,
+		},
+	})
+	require.NoError(t, err)
+	paths := []string{}
+	files := []gofs.DirEntry{}
+	err = f.Walk(context.TODO(), "", func(path string, entry gofs.DirEntry, err error) error {
+		require.NoError(t, err)
+		paths = append(paths, path)
+		files = append(files, entry)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, paths, []string{"1", "1/dir", "1/dir/foo", "2", "2/dir", "2/dir/bar"})
+	require.Equal(t, "1", files[0].Name())
+	require.Equal(t, "dir", files[1].Name())
+	require.Equal(t, "foo", files[2].Name())
+}

--- a/send.go
+++ b/send.go
@@ -144,7 +144,11 @@ func (s *sender) sendFile(h *sendHandle) error {
 
 func (s *sender) walk(ctx context.Context) error {
 	var i uint32 = 0
-	err := s.fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+	err := s.fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fi, err := entry.Info()
 		if err != nil {
 			return err
 		}

--- a/tarwriter.go
+++ b/tarwriter.go
@@ -15,8 +15,13 @@ import (
 
 func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	err := fs.Walk(ctx, func(path string, fi os.FileInfo, err error) error {
+	err := fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		fi, err := entry.Info()
+		if err != nil {
 			return err
 		}
 		stat, ok := fi.Sys().(*types.Stat)


### PR DESCRIPTION
This patch creates a new FilterFS to pair with a new FilterOpt, which contains the old WalkOpt parameters.

Essentially, this splits the functionality of the old FS into a new FS and the FilterFS. The new FS implemenation simply performs operations over a specified local filesystem, while the FilterFS wraps an existing FS implementation to apply filtering patterns.

This allows the same logic for filtering to apply to *any* underlying filesystem, for example, the StaticFS and MergeFS implementations in BuildKit (see https://github.com/moby/buildkit/pull/4094).

To do this, we also make some reasonably substantial changes to the developer-facing API. We need to use fs.WalkDirFunc instead of the old filepath.WalkFunc, which is required to preserve the lazy stat() semantics from b9e22fc139c520a1339bd31b9abc7c537d9d1623.

Existing implementations and callers of FS should fairly easily be able to update to support the new API, which just requires updating to support a new "path" parameter, and modify the signature to be fs.WalkDirFunc (which may actually improve performance depending on the exact usage).