### PR TITLE
copy: fix to respect most significant octet of given permission in copyFileInfo

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -30,12 +30,15 @@ func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 
 	m := fi.Mode()
 	if c.mode != nil {
-		m = os.FileMode(*c.mode & 0777)
-		sb := *c.mode & 0777
-		if sb != 0 {
-			m |= os.FileMode(sb)
-		} else {
-			m |= m & ^os.FileMode(0777)
+		m = os.FileMode(*c.mode).Perm()
+		if *c.mode&syscall.S_ISGID != 0 {
+			m |= os.ModeSetgid
+		}
+		if *c.mode&syscall.S_ISUID != 0 {
+			m |= os.ModeSetuid
+		}
+		if *c.mode&syscall.S_ISVTX != 0 {
+			m |= os.ModeSticky
 		}
 	}
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {

--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -30,7 +30,13 @@ func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 
 	m := fi.Mode()
 	if c.mode != nil {
-		m = (m & ^os.FileMode(0777)) | os.FileMode(*c.mode&0777)
+		m = os.FileMode(*c.mode & 0777)
+		sb := *c.mode & 0777
+		if sb != 0 {
+			m |= os.FileMode(sb)
+		} else {
+			m |= m & ^os.FileMode(0777)
+		}
 	}
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {
 		if err := os.Chmod(name, m); err != nil {

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -31,12 +31,15 @@ func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 
 	m := fi.Mode()
 	if c.mode != nil {
-		m = os.FileMode(*c.mode & 0777)
-		sb := *c.mode & 0777
-		if sb != 0 {
-			m |= os.FileMode(sb)
-		} else {
-			m |= m & ^os.FileMode(0777)
+		m = os.FileMode(*c.mode).Perm()
+		if *c.mode&syscall.S_ISGID != 0 {
+			m |= os.ModeSetgid
+		}
+		if *c.mode&syscall.S_ISUID != 0 {
+			m |= os.ModeSetuid
+		}
+		if *c.mode&syscall.S_ISVTX != 0 {
+			m |= os.ModeSticky
 		}
 	}
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -31,7 +31,13 @@ func (c *copier) copyFileInfo(fi os.FileInfo, src, name string) error {
 
 	m := fi.Mode()
 	if c.mode != nil {
-		m = (m & ^os.FileMode(0777)) | os.FileMode(*c.mode&0777)
+		m = os.FileMode(*c.mode & 0777)
+		sb := *c.mode & 0777
+		if sb != 0 {
+			m |= os.FileMode(sb)
+		} else {
+			m |= m & ^os.FileMode(0777)
+		}
 	}
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {
 		if err := os.Chmod(name, m); err != nil {

--- a/copy/copy_unix_test.go
+++ b/copy/copy_unix_test.go
@@ -56,3 +56,33 @@ func TestCopyDevicesAndFifo(t *testing.T) {
 	assert.NotEqual(t, os.ModeSocket, fi.Mode()&os.ModeSocket) // socket copied as stub
 	assert.Equal(t, os.FileMode(0555), fi.Mode()&0777)
 }
+
+func TestCopySetuid(t *testing.T) {
+	requiresRoot(t)
+
+	t1 := t.TempDir()
+
+	err := mknod(filepath.Join(t1, "char"), unix.S_IFCHR|0444, int(unix.Mkdev(1, 9)))
+	require.NoError(t, err)
+
+	t2 := t.TempDir()
+
+	err = Copy(context.TODO(), t1, ".", t2, ".")
+	require.NoError(t, err)
+
+	fi, err := os.Lstat(filepath.Join(t2, "char"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0444), fi.Mode()&07777)
+
+	t3 := t.TempDir()
+
+	p := 04444
+	err = Copy(context.TODO(), t1, ".", t3, ".", WithCopyInfo(CopyInfo{
+		Mode: &p,
+	}))
+	require.NoError(t, err)
+
+	fi, err = os.Lstat(filepath.Join(t3, "char"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(04444), fi.Mode()&07777)
+}


### PR DESCRIPTION
This PR fixes `(*copier).copyFileInfo()` to respect special bits specified in the copier struct. It causes [the BuildKit issue](https://github.com/moby/buildkit/issues/3920) where `COPY --chmod` doesn't respect the most significant octet of the Unix Permission.

This behavior might be intended because setting setuid/setgid to an executable file was known as an anti-pattern in terms of security. However, this command should not ignore them implicitly if the user understands its drawbacks and desires to set them.

## Additional Information

It seems Go's `os.FileMode` has its internal representation of special bits. We need to convert special bits to internal representation to set them properly. 

> Additionally, when os.Chmod() runs, it [actively discards](https://cs.opensource.google/go/go/+/refs/tags/go1.17.6:src/os/file_posix.go;l=62-88) anything past the first 9 bits (owner, group, other / read, write, execute) and uses its own internal representation to set the special file mode bits.
https://github.com/coreos/ignition/issues/1301#issue-1099348447