### PR TITLE
ci: bench job to run test benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,46 @@ jobs:
         with:
           file: ./coverage.txt
           flags: unit,freebsd
+
+  bench:
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write  # deployments permission to deploy GitHub pages website
+      contents: write  # contents permission to update benchmark contents in bench-gh-pages branch
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache-dependency-path: |
+            go.sum
+            bench/go.sum
+      -
+        name: Test
+        run: |
+          set -ex
+          mkdir ./bin
+          go mod download
+          go test -bench=. . | tee ./bin/temp_bench.txt
+          head -n -2 ./bin/temp_bench.txt > ./bin/bench.txt
+          cd ./bench
+          go mod download
+          BENCH_FILE_SIZE=10000 go test -bench=. . | tee ../bin/temp_bench.txt
+          awk 'NR > 4 {print buf[NR%3]} {buf[NR%3] = $0}' ../bin/temp_bench.txt >> ../bin/bench.txt
+      -
+        name: Result
+        run: |
+          cat ./bin/bench.txt
+      -
+        name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@cc9ac13ce81036c9b67fcfe2cb95ca366684b9ea  # v1.19.3
+        with:
+          tool: go
+          output-file-path: ./bin/bench.txt
+          summary-always: true
+          gh-pages-branch: bench-gh-pages
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/bench/diffcopy.go
+++ b/bench/diffcopy.go
@@ -21,7 +21,11 @@ func diffCopy(proto bool, src, dest string) error {
 	}
 
 	eg.Go(func() error {
-		return fsutil.Send(ctx, s1, fsutil.NewFS(src, nil), nil)
+		fs, err := fsutil.NewFS(src)
+		if err != nil {
+			return err
+		}
+		return fsutil.Send(ctx, s1, fs, nil)
 	})
 	eg.Go(func() error {
 		return fsutil.Receive(ctx, s2, dest, fsutil.ReceiveOpt{})


### PR DESCRIPTION
This runs test benchmark using https://github.com/benchmark-action/github-action-benchmark. Will send results on GitHub Pages (branch `bench-gh-pages`) to compare results across run. Will look like this: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#charts-on-github-pages

<img width="657" alt="main" src="https://github.com/tonistiigi/fsutil/assets/1951866/9a3a4f58-bc57-4db8-bff3-31cc8244fb80">
