### PR TITLE
Fix `FilterFS` when skipping lazy parent directories

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -356,8 +356,11 @@ func (fs *filterFS) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc
 				}
 				if fs.mapFn != nil {
 					result := fs.mapFn(parentStat.Path, parentStat)
-					if result == MapResultSkipDir || result == MapResultExclude {
+					if result == MapResultExclude {
 						continue
+					} else if result == MapResultSkipDir {
+						parentDirs[i].skipFn = true
+						return filepath.SkipDir
 					}
 				}
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -143,6 +143,30 @@ file bar/foo
 `), b.String())
 }
 
+func TestWalkerIncludeReturnSkipDir(t *testing.T) {
+	d, err := tmpDir(changeStream([]string{
+		"ADD foo dir",
+		"ADD foo/x dir",
+		"ADD foo/y dir",
+		"ADD foo/x/a.txt file",
+		"ADD foo/y/b.txt file",
+	}))
+	assert.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	found := []string{}
+
+	err = Walk(context.Background(), d, &FilterOpt{
+		IncludePatterns: []string{"**/*.txt"},
+	}, func(path string, info gofs.FileInfo, err error) error {
+		found = append(found, path)
+		return filepath.SkipDir
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"foo"}, found)
+}
+
 func TestWalkerExclude(t *testing.T) {
 	d, err := tmpDir(changeStream([]string{
 		"ADD bar file",


### PR DESCRIPTION
Original issue found by @vito in https://github.com/dagger/dagger/issues/6687.

Split into two commits, both with slightly different issues:
- `filter: allow SkipDir return with lazy parents`. Ensures that walker functions that return `filepath.SkipDir` are always respected, even when evaluated as a lazy parent function (see commit for more details).
- `filter: ensure MapResult is followed for parent directories`. Ensures that the `FilterFS` Map option for `MapResultSkipDir` is always respected, even when evaluated as a lazy parent function (see commit for more details).

These issues seem to have been present for a while (including prior to #167, which introduced `FilterFS`, where the issue was still present in `fsutil.Walk`).
- The first issue seems to have appeared in https://github.com/tonistiigi/fsutil/pull/108, when lazy parents were introduced.
- The second issues seems to have appeared in https://github.com/tonistiigi/fsutil/pull/130, when map options were introduced.