### PR TITLE
Codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           directory: ${{ env.DESTDIR }}/coverage
           flags: unit,${{ matrix.mode }},go-${{ matrix.go }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-os:
     runs-on: ${{ matrix.os }}
@@ -121,6 +122,7 @@ jobs:
           file: ./coverage.txt
           env_vars: RUNNER_OS
           flags: unit,go-${{ matrix.go }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-freebsd-amd64:
     runs-on: macos-13
@@ -174,3 +176,4 @@ jobs:
         with:
           file: ./coverage.txt
           flags: unit,freebsd
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:  # settings affecting project coverage
+      default:
+        target: auto  # auto % coverage target
+        threshold: 1%  # allow for 1% reduction of coverage without failing
+    patch: off
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
Similar to https://github.com/moby/buildkit/pull/4660: https://github.com/tonistiigi/fsutil/actions/runs/7956366236/job/21716950079#step:5:32

![image](https://github.com/tonistiigi/fsutil/assets/1951866/c5ac91e5-0f37-4f9b-81c3-a5f30ccfe55d)

We don't have any coverage report on the main branch: https://app.codecov.io/gh/tonistiigi/fsutil

![image](https://github.com/tonistiigi/fsutil/assets/1951866/bbbb82c7-dbbb-4585-bf5a-cdbe0602abc8)

That's because Codecov token is required since https://github.com/codecov/codecov-action/releases/tag/v4.0.0.

@tonistiigi You will find the token at https://app.codecov.io/gh/tonistiigi/fsutil/settings. Then you can add it as repository secret named `CODECOV_TOKEN` at https://github.com/tonistiigi/fsutil/settings/secrets/actions

Also add codecov config similar to BuildKit one: https://github.com/moby/buildkit/blob/master/codecov.yml