### PR TITLE
send: ensure file path to unix form when sending files

### DIFF
--- a/send.go
+++ b/send.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -156,7 +157,7 @@ func (s *sender) walk(ctx context.Context) error {
 		if !ok {
 			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
-
+		stat.Path = filepath.ToSlash(stat.Path)
 		p := &types.Packet{
 			Type: types.PACKET_STAT,
 			Stat: stat,


### PR DESCRIPTION
fixes https://github.com/docker/buildx/issues/2207
closes #186
related to https://github.com/docker/buildx/issues/2207#issuecomment-1957316154

alternative to #186 to make sure unix-style path is sent through the wire so we don't need extra conversion on the receiver side.

cc @jedevc @gabriel-samfira 