### PR TITLE
Fix file transfers from windows to linux

### DIFF
--- a/diff_containerd.go
+++ b/diff_containerd.go
@@ -111,7 +111,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				if filter != nil {
 					filter(f2.path, &statCopy)
 				}
-				f2copy = &currentPath{path: filepath.FromSlash(f2.path), stat: &statCopy}
+				f2copy = &currentPath{path: f2.path, stat: &statCopy}
 			}
 			k, p := pathChange(f1, f2copy)
 			switch k {

--- a/diskwriter.go
+++ b/diskwriter.go
@@ -183,7 +183,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 		}
 	default:
 		isRegularFile = true
-		file, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY, fi.Mode()) //todo: windows
+		file, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY, fi.Mode())
 		if err != nil {
 			return errors.Wrapf(err, "failed to create %s", newPath)
 		}
@@ -313,7 +313,7 @@ type lazyFileWriter struct {
 
 func (lfw *lazyFileWriter) Write(dt []byte) (int, error) {
 	if lfw.f == nil {
-		file, err := os.OpenFile(lfw.dest, os.O_WRONLY, 0) //todo: windows
+		file, err := os.OpenFile(lfw.dest, os.O_WRONLY, 0)
 		if os.IsPermission(err) {
 			// retry after chmod
 			fi, er := os.Stat(lfw.dest)

--- a/diskwriter.go
+++ b/diskwriter.go
@@ -98,7 +98,7 @@ func (dw *DiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo, er
 		}
 	}()
 
-	destPath := filepath.Join(dw.dest, filepath.FromSlash(p))
+	destPath := filepath.Join(dw.dest, p)
 
 	if kind == ChangeKindDelete {
 		if dw.filter != nil {

--- a/receive.go
+++ b/receive.go
@@ -1,3 +1,33 @@
+// send.go and receive.go describe the fsutil file-transfer protocol, which
+// allows transferring file trees across a network connection.
+//
+// The protocol operates as follows:
+// - The client (the receiver) connects to the server (the sender).
+// - The sender walks the target tree lexicographically and sends a series of
+//   STAT packets that describe each file (an empty stat indicates EOF).
+// - The receiver sends a REQ packet for each file it requires the contents for,
+//   using the ID for the file (determined as its index in the STAT sequence).
+// - The sender sends a DATA packet with byte arrays for the contents of the
+//   file, associated with an ID (an empty array indicates EOF).
+// - Once the receiver has received all files it wants, it sends a FIN packet,
+//   and the file transfer is complete.
+// If an error is encountered on either side, an ERR packet is sent containing
+// a human-readable error.
+//
+// All paths transferred over the protocol are normalized to unix-style paths,
+// regardless of which platforms are present on either side. These path
+// conversions are performed right before sending a STAT packet (for the
+// sender) or right after receiving the corresponding STAT packet (for the
+// receiver); this abstraction doesn't leak into the rest of fsutil, which
+// operates on native platform-specific paths.
+//
+// Note that in the case of cross-platform file transfers, the transfer is
+// best-effort. Some filenames that are valid on a unix sender would not be
+// valid on a windows receiver, so these paths are rejected as they are
+// received. Additionally, file metadata, like user/group owners and xattrs do
+// not have an exact correspondence on windows, and so would be discarded by
+// a windows receiver.
+
 package fsutil
 
 import (


### PR DESCRIPTION
This PR should fix file transfers from Windows to Linux (as is the case with docker-on-windows), and fixes https://github.com/moby/buildkit/pull/4806 https://github.com/moby/buildkit/issues/4741 (cc @profnandaa)

Also fixes https://github.com/dagger/dagger/issues/6923.

There are two parts, split into separate commits. This also could probably do with some tests :smile: 

## Reading unix paths as windows ones

Essentially, this change is wrong (cc @crazy-max): https://github.com/tonistiigi/fsutil/pull/173/files#diff-7dd945edf522324729284de47c3bdb062155cc945eaec235fc564631ae4e91b5

The validator consumes data *directly* off of the wire, which is guaranteed to be in unix-path form (see https://github.com/moby/buildkit/pull/4806#pullrequestreview-1965145911). Therefore, we should avoid using the platform-specific `filepath` package, and instead use the unix-specific `path` package.

## Keeping file map keys consistent

The change here https://github.com/tonistiigi/fsutil/pull/173/files#diff-7e712d320828705efdc283be20c75b6afc94b7327362cdd0e4e96fc6c72e645cR114 causes the `receiver.files` map to be indexed in `asyncDataFunc` by a windows path, but we explicitly store the data using a unix path.

The solution here is to make sure we propagate the *correct* path downwards, always using unix paths.