### PR TITLE
recv: translate linkname to wire format

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -224,6 +224,7 @@ func (r *receiver) run(ctx context.Context) error {
 					return errors.WithStack(&os.PathError{Path: p.Stat.Path, Err: syscall.EINVAL, Op: "unrepresentable path"})
 				}
 				p.Stat.Path = path
+				p.Stat.Linkname = filepath.FromSlash(p.Stat.Linkname)
 
 				if fileCanRequestData(os.FileMode(p.Stat.Mode)) {
 					r.mu.Lock()

--- a/send.go
+++ b/send.go
@@ -161,6 +161,7 @@ func (s *sender) walk(ctx context.Context) error {
 			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
 		}
 		stat.Path = filepath.ToSlash(stat.Path)
+		stat.Linkname = filepath.ToSlash(stat.Linkname)
 		p := &types.Packet{
 			Type: types.PACKET_STAT,
 			Stat: stat,


### PR DESCRIPTION
Follow-up from https://github.com/tonistiigi/fsutil/pull/196#pullrequestreview-2007019635.

I *think* this is the right approach?

I'm kinda of struggling to understand what the desired interface is here - the sender is fairly straightforward, since we just host an `FS` object (which is platform-specific). The receiver is a bit harder, since it can take a filter function, and various `include`/`exclude` parameters - should those functions refer to platform-specific paths? Or should they refer to unix-style wire paths?

This feels like it would fix the issue where the linknames are wrong (I think this was introduced in https://github.com/tonistiigi/fsutil/pull/173, when we started explicitly converting to unix paths on the wire). Something doesn't feel right here though.