### PR TITLE
fix hardlink filter regression

### DIFF
--- a/hardlinks.go
+++ b/hardlinks.go
@@ -1,6 +1,9 @@
 package fsutil
 
 import (
+	"context"
+	"io"
+	gofs "io/fs"
 	"os"
 	"syscall"
 
@@ -45,4 +48,69 @@ func (v *Hardlinks) HandleChange(kind ChangeKind, p string, fi os.FileInfo, err 
 	}
 
 	return nil
+}
+
+// WithHardlinkReset returns a FS that fixes hardlinks for FS that has been filtered
+// so that original hardlink sources might be missing
+func WithHardlinkReset(fs FS) FS {
+	return &hardlinkFilter{fs: fs}
+}
+
+type hardlinkFilter struct {
+	fs FS
+}
+
+var _ FS = &hardlinkFilter{}
+
+func (r *hardlinkFilter) Walk(ctx context.Context, target string, fn gofs.WalkDirFunc) error {
+	seenFiles := make(map[string]string)
+	return r.fs.Walk(ctx, target, func(path string, entry gofs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		fi, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		if fi.IsDir() || fi.Mode()&os.ModeSymlink != 0 {
+			return fn(path, entry, nil)
+		}
+
+		stat, ok := fi.Sys().(*types.Stat)
+		if !ok {
+			return errors.WithStack(&os.PathError{Path: path, Err: syscall.EBADMSG, Op: "fileinfo without stat info"})
+		}
+
+		if stat.Linkname != "" {
+			if v, ok := seenFiles[stat.Linkname]; !ok {
+				seenFiles[stat.Linkname] = stat.Path
+				stat.Linkname = ""
+				entry = &dirEntryWithStat{DirEntry: entry, stat: stat}
+			} else {
+				if v != stat.Path {
+					stat.Linkname = v
+					entry = &dirEntryWithStat{DirEntry: entry, stat: stat}
+				}
+			}
+		}
+
+		seenFiles[path] = stat.Path
+
+		return fn(path, entry, nil)
+	})
+}
+
+func (r *hardlinkFilter) Open(p string) (io.ReadCloser, error) {
+	return r.fs.Open(p)
+}
+
+type dirEntryWithStat struct {
+	gofs.DirEntry
+	stat *types.Stat
+}
+
+func (d *dirEntryWithStat) Info() (gofs.FileInfo, error) {
+	return &StatInfo{d.stat}, nil
 }

--- a/send.go
+++ b/send.go
@@ -29,7 +29,7 @@ type Stream interface {
 func Send(ctx context.Context, conn Stream, fs FS, progressCb func(int, bool)) error {
 	s := &sender{
 		conn:         &syncStream{Stream: conn},
-		fs:           fs,
+		fs:           WithHardlinkReset(fs),
 		files:        make(map[uint32]string),
 		progressCb:   progressCb,
 		sendpipeline: make(chan *sendHandle, 128),


### PR DESCRIPTION
fix https://github.com/moby/buildkit/issues/4831

With the refactor to FilterFS the hardlink handling was changed so that the hardlink detection is in a separate FS instance and then FilterFS is layered on top of it. This means that the file that was the source for the hardlink could be filtered out, but the Stat pointing to that link is still sent as is.

New function validates if source files are not present in FS anymore and correct the linking. It could be better if all the FS implementation did this automatically, but there is quite a lot of layering going on atm. with multiple layers of FilterFS that would all need to keep own hardlink memory, so atm. the new function is only called before send.