### PR TITLE
Fixup fallout with new FS changed API

### DIFF
--- a/bench/diffcopy.go
+++ b/bench/diffcopy.go
@@ -21,7 +21,11 @@ func diffCopy(proto bool, src, dest string) error {
 	}
 
 	eg.Go(func() error {
-		return fsutil.Send(ctx, s1, fsutil.NewFS(src, nil), nil)
+		fs, err := fsutil.NewFS(src)
+		if err != nil {
+			panic(err)
+		}
+		return fsutil.Send(ctx, s1, fs, nil)
 	})
 	eg.Go(func() error {
 		return fsutil.Receive(ctx, s2, dest, fsutil.ReceiveOpt{})


### PR DESCRIPTION
Fix for this:

```
# github.com/tonistiigi/fsutil/bench
src/github.com/tonistiigi/fsutil/bench/diffcopy.go:24:31: multiple-value fsutil.NewFS(src, nil) (value of type (fsutil.FS, error)) in sin
gle-value context
src/github.com/tonistiigi/fsutil/bench/diffcopy.go:24:49: too many arguments in call to fsutil.NewFS
        have (string, nil)
        want (string)
```