### PR TITLE
fix: clear ModeIrregular on directories on Windows

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -20,7 +20,7 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 
 	stat := &types.Stat{
 		Path:    filepath.FromSlash(relpath),
-		Mode:    uint32(fi.Mode()),
+		Mode:    modeBits(fi),
 		ModTime: fi.ModTime().UnixNano(),
 	}
 

--- a/stat_unix.go
+++ b/stat_unix.go
@@ -70,3 +70,7 @@ func major(device uint64) uint64 {
 func minor(device uint64) uint64 {
 	return (device & 0xff) | ((device >> 12) & 0xfff00)
 }
+
+func modeBits(fi os.FileInfo) uint32 {
+	return uint32(fi.Mode())
+}

--- a/stat_windows.go
+++ b/stat_windows.go
@@ -15,3 +15,16 @@ func loadXattr(_ string, _ *types.Stat) error {
 
 func setUnixOpt(_ os.FileInfo, _ *types.Stat, _ string, _ map[uint64]string) {
 }
+
+func modeBits(fi os.FileInfo) uint32 {
+	mode := fi.Mode()
+	// Go 1.23 an above will set ModeIrregular for directories with reparse tags
+	// that it doesn't understand. Clear it to make the mode consistent with
+	// the expectations for ModeIrregular on Unix.
+	// See https://github.com/golang/go/blob/bd80d8956f3062d2b2bff2d7da6b879dfa909f12/src/os/types_windows.go#L227
+	// and https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
+	if mode&os.ModeDir != 0 {
+		mode &^= os.ModeIrregular
+	}
+	return uint32(mode)
+}


### PR DESCRIPTION
Since go1.23, directories with an unknown reparse tag will have the
irregular bit set. We do not know exactly which scenario causes this, but
there are many different reparse tags that can be set and go only handles
3 of them.

This causes issues with other parts of the code because in Unix a directory
cannot have this bit set.

Add a workaround to clear this bit for directories on Windows.
