### PR TITLE
ci: fix freebsd package repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,10 @@ jobs:
         name: Install vagrant
         run: |
           set -x
+          wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update
-          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt ruby-libvirt
+          sudo apt-get install -y libvirt-dev libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt ruby-libvirt
           sudo systemctl enable --now libvirtd
           sudo chmod a+rw /var/run/libvirt/libvirt-sock
           vagrant plugin install vagrant-libvirt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  DESTDIR: ./bin
-
 on:
   workflow_dispatch:
   schedule:
@@ -15,6 +12,10 @@ on:
     branches:
       - master
   pull_request:
+
+env:
+  DESTDIR: ./bin
+  GO_VERSION: "1.23"
 
 jobs:
   validate:
@@ -134,6 +135,10 @@ jobs:
         name: Prepare
         run: |
           echo "VAGRANT_FILE=hack/Vagrantfile.${{ matrix.os }}" >> $GITHUB_ENV
+
+          # Sets semver Go version to be able to download tarball during vagrant setup
+          goVersion=$(curl --silent "https://go.dev/dl/?mode=json&include=all" | jq -r '.[].files[].version' | uniq | sed -e 's/go//' | sort -V | grep $GO_VERSION | tail -1)
+          echo "GO_VERSION=$goVersion" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4

--- a/hack/Vagrantfile.freebsd
+++ b/hack/Vagrantfile.freebsd
@@ -10,6 +10,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
       set -ex
+      freebsd-version -kru
+      # switching to "release_2" ensures compatibility with the current Vagrant box
+      sed -i '' 's/latest/release_2/' /usr/local/etc/pkg/repos/FreeBSD.conf
       pkg bootstrap
       fetch https://go.dev/dl/go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz
       tar -C /usr/local -xzf go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz

--- a/hack/Vagrantfile.freebsd
+++ b/hack/Vagrantfile.freebsd
@@ -9,9 +9,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
+      set -ex
       pkg bootstrap
-      pkg install -y go123
-      ln -s /usr/local/bin/go123 /usr/local/bin/go
+      fetch https://go.dev/dl/go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz
+      tar -C /usr/local -xzf go#{ENV['GO_VERSION']}.freebsd-amd64.tar.gz
+      ln -s /usr/local/go/bin/go /usr/local/bin/go
     SHELL
   end
 end

--- a/hack/Vagrantfile.netbsd
+++ b/hack/Vagrantfile.netbsd
@@ -9,13 +9,24 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      # update CA certs
+      set -ex
+      mkdir -p /var/tmp
+      chmod 1777 /var/tmp
+
       pkgin -y install mozilla-rootcerts
       mozilla-rootcerts install
 
-      ftp https://go.dev/dl/go1.23.2.netbsd-amd64.tar.gz
-      tar -C /tmp -xzf go1.23.2.netbsd-amd64.tar.gz
-      ln -s /tmp/go/bin/go /usr/bin/go
+      ftp https://go.dev/dl/go#{ENV['GO_VERSION']}.netbsd-amd64.tar.gz
+      tar -C /var/tmp -xzf go#{ENV['GO_VERSION']}.netbsd-amd64.tar.gz
+
+      cat << 'EOF' > /usr/bin/go-wrapper
+      #!/bin/sh
+      export TMPDIR="/var/tmp"
+      exec /var/tmp/go/bin/go "$@"
+      EOF
+      chmod +x /usr/bin/go-wrapper
+
+      ln -s /usr/bin/go-wrapper /usr/bin/go
     SHELL
   end
 end

--- a/hack/Vagrantfile.openbsd
+++ b/hack/Vagrantfile.openbsd
@@ -9,8 +9,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "init", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
-      ftp https://go.dev/dl/go1.23.2.openbsd-amd64.tar.gz
-      tar -C /usr/local -xzf go1.23.2.openbsd-amd64.tar.gz
+      set -ex
+      ftp https://go.dev/dl/go#{ENV['GO_VERSION']}.openbsd-amd64.tar.gz
+      tar -C /usr/local -xzf go#{ENV['GO_VERSION']}.openbsd-amd64.tar.gz
       ln -s /usr/local/go/bin/go /usr/local/bin/go
     SHELL
   end


### PR DESCRIPTION
relates to: https://github.com/tonistiigi/fsutil/actions/runs/14326752686/job/40153584558#step:6:68

```
 ==> default: Machine booted and ready!
==> default: Installing rsync to the VM...
==> default: Rsyncing folder: /home/runner/work/fsutil/fsutil/ => /vagrant
==> default: Running provisioner: init (shell)...
    default: Running: inline script
    default: pkg already bootstrapped at /usr/local/sbin/pkg
    default: Updating FreeBSD repository catalogue...
    default: FreeBSD repository is up to date.
    default: All repositories are up to date.
    default: pkg: No packages available to install matching 'go123' have been found in the repositories
```

This is similar to https://github.com/moby/buildkit/pull/5893 but instead we can install Go from official binary release like we have done on Buildx repo: https://github.com/docker/buildx/pull/2995 so we don't need to install from package repo.