### PR TITLE
stat: ignore apple extended attributes

### DIFF
--- a/stat_test.go
+++ b/stat_test.go
@@ -3,6 +3,8 @@ package fsutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,4 +55,17 @@ func TestStat(t *testing.T) {
 	assert.NotZero(t, st.ModTime)
 	st.ModTime = 0
 	assert.Equal(t, &types.Stat{Path: "sock", Mode: 0755 /* ModeSocket not set */}, st)
+}
+
+func TestStat_SkipAppleXattrs(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("skipping test that requires darwin")
+	}
+
+	st, err := Stat("Dockerfile")
+	assert.NoError(t, err)
+
+	for key := range st.Xattrs {
+		assert.False(t, strings.HasPrefix(key, "com.apple."))
+	}
 }

--- a/stat_unix.go
+++ b/stat_unix.go
@@ -5,12 +5,15 @@ package fsutil
 
 import (
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
+
+const xattrApplePrefix = "com.apple."
 
 func loadXattr(origpath string, stat *types.Stat) error {
 	xattrs, err := sysx.LListxattr(origpath)
@@ -23,14 +26,27 @@ func loadXattr(origpath string, stat *types.Stat) error {
 	if len(xattrs) > 0 {
 		m := make(map[string][]byte)
 		for _, key := range xattrs {
-			v, err := sysx.LGetxattr(origpath, key)
-			if err == nil {
+			if skipXattr(key) {
+				continue
+			}
+
+			if v, err := sysx.LGetxattr(origpath, key); err == nil {
 				m[key] = v
 			}
 		}
-		stat.Xattrs = m
+
+		if len(m) > 0 {
+			stat.Xattrs = m
+		}
 	}
 	return nil
+}
+
+func skipXattr(key string) bool {
+	if strings.HasPrefix(key, xattrApplePrefix) {
+		return true
+	}
+	return false
 }
 
 func setUnixOpt(fi os.FileInfo, stat *types.Stat, path string, seenFiles map[uint64]string) {


### PR DESCRIPTION
Extended attributes from `com.apple` will bust remote layer caches
and shouldn't be transferred to a Linux environment. Skip loading these
extended attributes as part of loading xattrs.

Fixes docker/for-mac#7636.

Replaces moby/buildkit#5899.

Original credit to @tylermichael for creating an initial solution.
