### PR TITLE
Removed unused import from stat.proto

### DIFF
--- a/types/stat.proto
+++ b/types/stat.proto
@@ -4,8 +4,6 @@ package fsutil.types;
 
 option go_package = "github.com/tonistiigi/fsutil/types";
 
-import "github.com/planetscale/vtprotobuf/vtproto/ext.proto";
-
 message Stat {
   string path = 1;
   uint32 mode = 2;


### PR DESCRIPTION
`protoc` complains `stat.proto:7:1: warning: Import github.com/planetscale/vtprotobuf/vtproto/ext.proto is unused.` and I'm trying to build with `--fatal-warnings`.