### PR TITLE
fix: send: use platform-specific root path

### DIFF
--- a/send.go
+++ b/send.go
@@ -148,7 +148,8 @@ func (s *sender) sendFile(h *sendHandle) error {
 
 func (s *sender) walk(ctx context.Context) error {
 	var i uint32 = 0
-	err := s.fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
+	target := string(filepath.Separator)
+	err := s.fs.Walk(ctx, target, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Using "/" was causing a silent bug later on at
`fs.go:121` that is expecting platform-specific
separators. See discussion at https://github.com/moby/buildkit/pull/6007

Fix this by using `\\` on Windows and `/` on unix.