### PR TITLE
stat: add statfs method to perform stat on fs.FS interface

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -56,7 +57,11 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 }
 
 func Stat(path string) (*types.Stat, error) {
-	fi, err := os.Lstat(path)
+	return StatFS(os.DirFS("/"), path)
+}
+
+func StatFS(fsys gofs.FS, path string) (*types.Stat, error) {
+	fi, err := gofs.Lstat(fsys, path)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
The primary purpose of this is to enable using the `types.Stat` type in
combination with `os.OpenRoot` which can return an `fs.FS` compatible
interface. This way, `StatFS` can be used on a chroot filesystem safely.