### PR TITLE
copy: fix mode of created directories with unexpected umask

### DIFF
--- a/copy/mkdir.go
+++ b/copy/mkdir.go
@@ -2,12 +2,19 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 )
 
 // MkdirAll is forked os.MkdirAll
 func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]string, error) {
+	fixUmask := needsUmaskFix(perm)
+	return mkdirAll(path, perm, user, tm, fixUmask)
+}
+
+func mkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time, fixUmask bool) ([]string, error) {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := os.Stat(path)
 	if err == nil {
@@ -54,6 +61,16 @@ func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]str
 		}
 		return nil, err
 	}
+
+	// In general, this code should run with umask unset.
+	// At the same time, there are certain environments where we rely
+	// on this behavior and the umask causes the directory to be created
+	// with the wrong mode.
+	if fixUmask {
+		if err := os.Chmod(path, perm); err != nil {
+			return nil, err
+		}
+	}
 	createdDirs = append(createdDirs, path)
 
 	if err := Chown(path, nil, user); err != nil {
@@ -65,4 +82,36 @@ func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]str
 	}
 
 	return createdDirs, nil
+}
+
+var (
+	systemUmask     os.FileMode
+	systemUmaskOnce sync.Once
+)
+
+// needsUmaskFix will check if the requested permission would be affected by the umask.
+func needsUmaskFix(perm os.FileMode) bool {
+	systemUmaskOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "fsutil-umask-probe-")
+		if err != nil {
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		f, err := os.OpenFile(filepath.Join(dir, "probe"), os.O_CREATE|os.O_RDWR, 0777)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			return
+		}
+
+		// The bits that were masked out by the system umask are the bits
+		// that were requested (0777) but not present in the resulting mode.
+		systemUmask = 0777 &^ (fi.Mode() & os.ModePerm)
+	})
+	return perm&systemUmask != 0
 }

--- a/copy/mkdir_test.go
+++ b/copy/mkdir_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkdirUmaskFix(t *testing.T) {
+	tests := []struct {
+		name  string
+		umask os.FileMode
+		perm  os.FileMode
+	}{
+		{
+			name:  "default - world",
+			umask: 0022,
+			perm:  0777,
+		},
+		{
+			name:  "none - world",
+			umask: 0,
+			perm:  0777,
+		},
+		{
+			name:  "default - normal",
+			umask: 0022,
+			perm:  0755,
+		},
+		{
+			name:  "none - normal",
+			umask: 0,
+			perm:  0755,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Invoked both on start and cleanup just out of paranoia.
+			resetSystemUmaskCheck()
+			t.Cleanup(resetSystemUmaskCheck)
+
+			// Set the umask to our tested value and then reset it back.
+			umask := syscall.Umask(int(tt.umask))
+			t.Cleanup(func() { syscall.Umask(umask) })
+
+			path := filepath.Join(dir, "a/b/c")
+
+			createdDirs, err := MkdirAll(path, tt.perm, nil, nil)
+			require.NoError(t, err)
+			require.Len(t, createdDirs, 3)
+
+			for _, p := range createdDirs {
+				st, err := os.Stat(p)
+				require.NoError(t, err)
+				require.Equal(t, tt.perm, st.Mode()&os.ModePerm)
+			}
+		})
+	}
+}
+
+// resetSystemUmaskCheck resets the cached system umask so that the next call to
+// needsUmaskFix re-probes the environment.
+func resetSystemUmaskCheck() {
+	systemUmask = 0
+	systemUmaskOnce = sync.Once{}
+}


### PR DESCRIPTION
Adds some code to `MkdirAll` to check the current umask for the process
and fix the permission mode of the file when the umask would interfere
with the creation of the directory.
