### PR TITLE
copy: fix mode of created directories with unexpected umask

### DIFF
--- a/copy/mkdir.go
+++ b/copy/mkdir.go
@@ -2,12 +2,19 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 )
 
 // MkdirAll is forked os.MkdirAll
 func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]string, error) {
+	fixUmask := needsUmaskFix(perm)
+	return mkdirAll(path, perm, user, tm, fixUmask)
+}
+
+func mkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time, fixUmask bool) ([]string, error) {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := os.Stat(path)
 	if err == nil {
@@ -54,6 +61,16 @@ func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]str
 		}
 		return nil, err
 	}
+
+	// In general, this code should run with umask unset.
+	// At the same time, there are certain environments where we rely
+	// on this behavior and the umask causes the directory to be created
+	// with the wrong mode.
+	if fixUmask {
+		if err := os.Chmod(path, perm); err != nil {
+			return nil, err
+		}
+	}
 	createdDirs = append(createdDirs, path)
 
 	if err := Chown(path, nil, user); err != nil {
@@ -65,4 +82,36 @@ func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]str
 	}
 
 	return createdDirs, nil
+}
+
+var (
+	systemUmask     os.FileMode
+	systemUmaskOnce sync.Once
+)
+
+// needsUmaskFix will check if the requested permission would be affected by the umask.
+func needsUmaskFix(perm os.FileMode) bool {
+	systemUmaskOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "fsutil-umask-probe-")
+		if err != nil {
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		f, err := os.OpenFile(filepath.Join(dir, "probe"), os.O_CREATE|os.O_RDWR, 0777)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			return
+		}
+
+		// The bits that were masked out by the system umask are the bits
+		// that were requested (0777) but not present in the resulting mode.
+		systemUmask = 0777 &^ (fi.Mode() & os.ModePerm)
+	})
+	return perm&systemUmask != 0
 }

--- a/copy/mkdir.go
+++ b/copy/mkdir.go
@@ -2,19 +2,14 @@ package fs
 
 import (
 	"os"
-	"path/filepath"
-	"sync"
 	"syscall"
 	"time"
 )
 
+var UmaskIsZero = false
+
 // MkdirAll is forked os.MkdirAll
 func MkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time) ([]string, error) {
-	fixUmask := needsUmaskFix(perm)
-	return mkdirAll(path, perm, user, tm, fixUmask)
-}
-
-func mkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time, fixUmask bool) ([]string, error) {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := os.Stat(path)
 	if err == nil {
@@ -66,7 +61,7 @@ func mkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time, fixUma
 	// At the same time, there are certain environments where we rely
 	// on this behavior and the umask causes the directory to be created
 	// with the wrong mode.
-	if fixUmask {
+	if !UmaskIsZero {
 		if err := os.Chmod(path, perm); err != nil {
 			return nil, err
 		}
@@ -82,36 +77,4 @@ func mkdirAll(path string, perm os.FileMode, user Chowner, tm *time.Time, fixUma
 	}
 
 	return createdDirs, nil
-}
-
-var (
-	systemUmask     os.FileMode
-	systemUmaskOnce sync.Once
-)
-
-// needsUmaskFix will check if the requested permission would be affected by the umask.
-func needsUmaskFix(perm os.FileMode) bool {
-	systemUmaskOnce.Do(func() {
-		dir, err := os.MkdirTemp("", "fsutil-umask-probe-")
-		if err != nil {
-			return
-		}
-		defer os.RemoveAll(dir)
-
-		f, err := os.OpenFile(filepath.Join(dir, "probe"), os.O_CREATE|os.O_RDWR, 0777)
-		if err != nil {
-			return
-		}
-		defer f.Close()
-
-		fi, err := f.Stat()
-		if err != nil {
-			return
-		}
-
-		// The bits that were masked out by the system umask are the bits
-		// that were requested (0777) but not present in the resulting mode.
-		systemUmask = 0777 &^ (fi.Mode() & os.ModePerm)
-	})
-	return perm&systemUmask != 0
 }

--- a/copy/mkdir_test.go
+++ b/copy/mkdir_test.go
@@ -5,7 +5,6 @@ package fs
 import (
 	"os"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"testing"
 
@@ -44,9 +43,8 @@ func TestMkdirUmaskFix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			// Invoked both on start and cleanup just out of paranoia.
-			resetSystemUmaskCheck()
-			t.Cleanup(resetSystemUmaskCheck)
+			UmaskIsZero = tt.umask == 0
+			t.Cleanup(func() { UmaskIsZero = false })
 
 			// Set the umask to our tested value and then reset it back.
 			umask := syscall.Umask(int(tt.umask))
@@ -65,11 +63,4 @@ func TestMkdirUmaskFix(t *testing.T) {
 			}
 		})
 	}
-}
-
-// resetSystemUmaskCheck resets the cached system umask so that the next call to
-// needsUmaskFix re-probes the environment.
-func resetSystemUmaskCheck() {
-	systemUmask = 0
-	systemUmaskOnce = sync.Once{}
 }

--- a/copy/mkdir_test.go
+++ b/copy/mkdir_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkdirUmaskFix(t *testing.T) {
+	tests := []struct {
+		name  string
+		umask os.FileMode
+		perm  os.FileMode
+	}{
+		{
+			name:  "default - world",
+			umask: 0022,
+			perm:  0777,
+		},
+		{
+			name:  "none - world",
+			umask: 0,
+			perm:  0777,
+		},
+		{
+			name:  "default - normal",
+			umask: 0022,
+			perm:  0755,
+		},
+		{
+			name:  "none - normal",
+			umask: 0,
+			perm:  0755,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Invoked both on start and cleanup just out of paranoia.
+			resetSystemUmaskCheck()
+			t.Cleanup(resetSystemUmaskCheck)
+
+			// Set the umask to our tested value and then reset it back.
+			umask := syscall.Umask(int(tt.umask))
+			t.Cleanup(func() { syscall.Umask(umask) })
+
+			path := filepath.Join(dir, "a/b/c")
+
+			createdDirs, err := MkdirAll(path, tt.perm, nil, nil)
+			require.NoError(t, err)
+			require.Len(t, createdDirs, 3)
+
+			for _, p := range createdDirs {
+				st, err := os.Stat(p)
+				require.NoError(t, err)
+				require.Equal(t, tt.perm, st.Mode()&os.ModePerm)
+			}
+		})
+	}
+}
+
+// resetSystemUmaskCheck resets the cached system umask so that the next call to
+// needsUmaskFix re-probes the environment.
+func resetSystemUmaskCheck() {
+	systemUmask = 0
+	systemUmaskOnce = sync.Once{}
+}

--- a/copy/mkdir_test.go
+++ b/copy/mkdir_test.go
@@ -12,6 +12,27 @@ import (
 )
 
 func TestMkdirUmaskFix(t *testing.T) {
+	modes := []struct {
+		name  string
+		setup func(t *testing.T, umask os.FileMode)
+	}{
+		{
+			name: "umask",
+			setup: func(t *testing.T, umask os.FileMode) {
+				oldUmask := syscall.Umask(int(umask))
+				t.Cleanup(func() { syscall.Umask(oldUmask) })
+			},
+		},
+		{
+			name: "zero umask",
+			setup: func(t *testing.T, _ os.FileMode) {
+				umask := syscall.Umask(0)
+				t.Cleanup(func() { syscall.Umask(umask) })
+				UmaskIsZero = true
+				t.Cleanup(func() { UmaskIsZero = false })
+			},
+		},
+	}
 	tests := []struct {
 		name  string
 		umask os.FileMode
@@ -39,28 +60,71 @@ func TestMkdirUmaskFix(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
+	for _, mode := range modes {
+		for _, tt := range tests {
+			t.Run(mode.name+"/"+tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				mode.setup(t, tt.umask)
 
-			UmaskIsZero = tt.umask == 0
-			t.Cleanup(func() { UmaskIsZero = false })
+				path := filepath.Join(dir, "a/b/c")
 
-			// Set the umask to our tested value and then reset it back.
-			umask := syscall.Umask(int(tt.umask))
-			t.Cleanup(func() { syscall.Umask(umask) })
-
-			path := filepath.Join(dir, "a/b/c")
-
-			createdDirs, err := MkdirAll(path, tt.perm, nil, nil)
-			require.NoError(t, err)
-			require.Len(t, createdDirs, 3)
-
-			for _, p := range createdDirs {
-				st, err := os.Stat(p)
+				createdDirs, err := MkdirAll(path, tt.perm, nil, nil)
 				require.NoError(t, err)
-				require.Equal(t, tt.perm, st.Mode()&os.ModePerm)
-			}
+				require.Len(t, createdDirs, 3)
+
+				for _, p := range createdDirs {
+					st, err := os.Stat(p)
+					require.NoError(t, err)
+					require.Equal(t, tt.perm, st.Mode()&os.ModePerm)
+				}
+			})
+		}
+	}
+}
+
+func TestMkdirUmaskFixExistingPath(t *testing.T) {
+	modes := []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{
+			name: "umask",
+			setup: func(t *testing.T) {
+				umask := syscall.Umask(0022)
+				t.Cleanup(func() { syscall.Umask(umask) })
+			},
+		},
+		{
+			name: "zero umask",
+			setup: func(t *testing.T) {
+				umask := syscall.Umask(0)
+				t.Cleanup(func() { syscall.Umask(umask) })
+				UmaskIsZero = true
+				t.Cleanup(func() { UmaskIsZero = false })
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mode.setup(t)
+
+			existing := filepath.Join(dir, "existing")
+			require.NoError(t, os.Mkdir(existing, 0700))
+
+			newPath := filepath.Join(existing, "new")
+			createdDirs, err := MkdirAll(filepath.Join(newPath, "."), 0770, nil, nil)
+			require.NoError(t, err)
+			require.Equal(t, []string{newPath}, createdDirs)
+
+			st, err := os.Stat(existing)
+			require.NoError(t, err)
+			require.Equal(t, os.FileMode(0700), st.Mode()&os.ModePerm)
+
+			st, err = os.Stat(newPath)
+			require.NoError(t, err)
+			require.Equal(t, os.FileMode(0770), st.Mode()&os.ModePerm)
 		})
 	}
 }


### PR DESCRIPTION
replaces #247

Updated to use a global variable to avoid the need for permissions to write to the temp directory.