### PR TITLE
ci: switch to pygolo/openbsd7 vagrant image

### DIFF
--- a/hack/Vagrantfile.openbsd
+++ b/hack/Vagrantfile.openbsd
@@ -2,7 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/openbsd7"
+  config.vm.box = "pygolo/openbsd7"
+  config.vm.box_version = "7.7"
   config.vm.boot_timeout = 900
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
   config.ssh.keep_alive = true


### PR DESCRIPTION
relates to https://github.com/tonistiigi/fsutil/actions/runs/26913960532/job/79399003080#step:6:67

switch to pygolo/openbsd7 vagrant image like buildx: https://github.com/docker/buildx/blob/ff92e6e0bd6b406578f3188a77e54d07a8481c09/hack/Vagrantfile.openbsd#L5-L6