### PR TITLE
ci: run OS tests with bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           go-version: ${{ matrix.go }}
       -
         name: Test
+        shell: bash
         run: |
           go test -coverprofile="coverage.txt" -covermode="atomic" ./...
           go tool cover -func="coverage.txt"

--- a/receive_test.go
+++ b/receive_test.go
@@ -218,6 +218,10 @@ func TestCopySwitchDirToFile(t *testing.T) {
 }
 
 func TestHardlinkFilter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hardlink stat linknames are not populated on windows")
+	}
+
 	d, err := tmpDir(changeStream([]string{
 		"ADD bar file data1",
 		"ADD foo file >bar",


### PR DESCRIPTION
Force the test-os workflow step to use bash so a failing go test command is not masked by a later coverage command on Windows PowerShell.