### PR TITLE
diff: compare file content by hash exchange for DiffContent

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -2,7 +2,9 @@ package fsutil
 
 import (
 	"context"
+	"crypto/sha256"
 	"hash"
+	"io"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
@@ -52,6 +54,9 @@ func getFSWalkerFn(newFS func() (FS, error)) walkerFn {
 			p := &currentPath{
 				path: path,
 				stat: stat,
+			}
+			if canContentCheck(stat) {
+				p.contentHash = contentHashForFS(ctx, fs, path)
 			}
 
 			select {
@@ -106,4 +111,39 @@ func mkrootstat(root Root, relpath string, fi os.FileInfo, inodemap map[uint64]s
 
 func emptyWalker(ctx context.Context, pathC chan<- *currentPath) error {
 	return nil
+}
+
+func contentHashForFS(ctx context.Context, fs FS, path string) func(context.Context) ([]byte, error) {
+	return func(hashCtx context.Context) ([]byte, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-hashCtx.Done():
+			return nil, hashCtx.Err()
+		default:
+		}
+
+		rc, err := fs.Open(path)
+		if err != nil {
+			return nil, err
+		}
+
+		buf := bufPool.Get().(*[]byte)
+		defer bufPool.Put(buf)
+
+		h := sha256.New()
+		if _, err := io.CopyBuffer(h, rc, *buf); err != nil {
+			rc.Close()
+			return nil, errors.WithStack(err)
+		}
+		if err := rc.Close(); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return h.Sum(nil), nil
+	}
+}
+
+func canContentCheck(stat *types.Stat) bool {
+	mode := os.FileMode(stat.Mode)
+	return mode.IsRegular() && stat.Linkname == ""
 }

--- a/diff_containerd.go
+++ b/diff_containerd.go
@@ -3,7 +3,6 @@ package fsutil
 import (
 	"bytes"
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,12 +50,10 @@ func (k ChangeKind) String() string {
 // computed during a directory changes calculation.
 type ChangeFunc func(ChangeKind, string, os.FileInfo, error) error
 
-const compareChunkSize = 32 * 1024
-
 type currentPath struct {
-	path string
-	stat *types.Stat
-	//	fullPath string
+	path        string
+	stat        *types.Stat
+	contentHash func(context.Context) ([]byte, error)
 }
 
 // doubleWalkDiff walks both directories to create a diff
@@ -69,7 +66,17 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 
 		f1, f2 *currentPath
 		rmdir  string
+
+		changes []diffChange
+		pending []pendingContentCheck
 	)
+	emitChange := func(kind ChangeKind, path string, stat *types.Stat) error {
+		if differ == DiffContent {
+			changes = append(changes, diffChange{kind: kind, path: path, stat: stat})
+			return nil
+		}
+		return changeFn(kind, path, &StatInfo{stat}, nil)
+	}
 	g.Go(func() error {
 		defer close(c1)
 		return a(ctx, c1)
@@ -111,7 +118,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				if filter != nil {
 					filter(f2.path, statCopy)
 				}
-				f2copy = &currentPath{path: f2.path, stat: statCopy}
+				f2copy = &currentPath{path: f2.path, stat: statCopy, contentHash: f2.contentHash}
 			}
 			k, p := pathChange(f1, f2copy)
 			switch k {
@@ -134,10 +141,12 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				}
 				f1 = nil
 			case ChangeKindModify:
-				same, err := sameFile(f1, f2copy, differ)
+				result, err := compareFile(f1, f2copy, differ)
 				if err != nil {
 					return err
 				}
+				lower := f1
+				upper := f2copy
 				if f1.stat.IsDir() && !f2copy.stat.IsDir() {
 					rmdir = f1.path + string(filepath.Separator)
 				} else if rmdir != "" {
@@ -146,12 +155,32 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b walkerFn, fil
 				f = f2.stat
 				f1 = nil
 				f2 = nil
-				if same {
+				switch result {
+				case fileCompareSame:
 					continue loop0
+				case fileCompareNeedsContentCheck:
+					pending = append(pending, pendingContentCheck{
+						changeIndex: len(changes),
+						lower:       lower,
+						upper:       upper,
+					})
 				}
 			}
-			if err := changeFn(k, p, &StatInfo{f}, nil); err != nil {
+			if err := emitChange(k, p, f); err != nil {
 				return err
+			}
+		}
+		if differ == DiffContent {
+			if err := resolveContentChecks(ctx, changes, pending); err != nil {
+				return err
+			}
+			for _, change := range changes {
+				if change.skip {
+					continue
+				}
+				if err := changeFn(change.kind, change.path, &StatInfo{change.stat}, nil); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -183,58 +212,97 @@ func pathChange(lower, upper *currentPath) (ChangeKind, string) {
 	}
 }
 
-func sameFile(f1, f2 *currentPath, differ DiffType) (same bool, retErr error) {
+type fileCompareResult int
+
+const (
+	fileCompareChanged fileCompareResult = iota
+	fileCompareSame
+	fileCompareNeedsContentCheck
+)
+
+type diffChange struct {
+	kind ChangeKind
+	path string
+	stat *types.Stat
+	skip bool
+}
+
+type pendingContentCheck struct {
+	changeIndex int
+	lower       *currentPath
+	upper       *currentPath
+}
+
+func compareFile(f1, f2 *currentPath, differ DiffType) (fileCompareResult, error) {
 	if differ == DiffNone {
-		return false, nil
+		return fileCompareChanged, nil
 	}
 	// If not a directory also check size, modtime, and content
 	if !f1.stat.IsDir() {
 		if f1.stat.Size != f2.stat.Size {
-			return false, nil
+			return fileCompareChanged, nil
 		}
 
 		if f1.stat.ModTime != f2.stat.ModTime {
-			return false, nil
+			return fileCompareChanged, nil
 		}
 	}
 
 	same, err := compareStat(f1.stat, f2.stat)
 	if err != nil || !same || differ == DiffMetadata {
-		return same, err
+		if same {
+			return fileCompareSame, err
+		}
+		return fileCompareChanged, err
 	}
-	return compareFileContent(f1.path, f2.path)
+
+	if !canContentCheck(f1.stat) || !canContentCheck(f2.stat) || f1.stat.Size == 0 {
+		return fileCompareSame, nil
+	}
+	if f1.contentHash == nil || f2.contentHash == nil {
+		return fileCompareChanged, nil
+	}
+	return fileCompareNeedsContentCheck, nil
 }
 
-func compareFileContent(p1, p2 string) (bool, error) {
-	f1, err := os.Open(p1)
-	if err != nil {
-		return false, err
+func resolveContentChecks(ctx context.Context, changes []diffChange, pending []pendingContentCheck) error {
+	if len(pending) == 0 {
+		return nil
 	}
-	defer f1.Close()
-	f2, err := os.Open(p2)
-	if err != nil {
-		return false, err
-	}
-	defer f2.Close()
 
-	b1 := make([]byte, compareChunkSize)
-	b2 := make([]byte, compareChunkSize)
-	for {
-		n1, err1 := f1.Read(b1)
-		if err1 != nil && err1 != io.EOF {
-			return false, err1
-		}
-		n2, err2 := f2.Read(b2)
-		if err2 != nil && err2 != io.EOF {
-			return false, err2
-		}
-		if n1 != n2 || !bytes.Equal(b1[:n1], b2[:n2]) {
-			return false, nil
-		}
-		if err1 == io.EOF && err2 == io.EOF {
-			return true, nil
+	lowerHashes := make([][]byte, len(pending))
+	upperHashes := make([][]byte, len(pending))
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(16)
+
+	for i, check := range pending {
+		g.Go(func() error {
+			hash, err := check.upper.contentHash(ctx)
+			if err != nil {
+				return err
+			}
+			upperHashes[i] = hash
+			return nil
+		})
+		g.Go(func() error {
+			hash, err := check.lower.contentHash(ctx)
+			if err != nil {
+				return err
+			}
+			lowerHashes[i] = hash
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	for i, check := range pending {
+		if bytes.Equal(lowerHashes[i], upperHashes[i]) {
+			changes[check.changeIndex].skip = true
 		}
 	}
+	return nil
 }
 
 // compareStat returns whether the stats are equivalent,

--- a/receive.go
+++ b/receive.go
@@ -7,6 +7,10 @@
 //   STAT packets that describe each file (an empty stat indicates EOF).
 // - The receiver sends a REQ packet for each file it requires the contents for,
 //   using the ID for the file (determined as its index in the STAT sequence).
+// - If content-based diffing is enabled, the receiver may first send HASH_REQ
+//   packets for files whose metadata matches. The sender replies with HASH
+//   packets containing SHA256 digests, allowing the receiver to avoid REQ for
+//   unchanged files.
 // - The sender sends a DATA packet with byte arrays for the contents of the
 //   file, associated with an ID (an empty array indicates EOF).
 // - Once the receiver has received all files it wants, it sends a FIN packet,
@@ -92,6 +96,7 @@ func newReceiver(conn Stream, opt ReceiveOpt) *receiver {
 		conn:          &syncStream{Stream: conn},
 		files:         make(map[string]uint32),
 		pipes:         make(map[uint32]io.WriteCloser),
+		hashWaiters:   make(map[uint32]chan hashResult),
 		notifyHashed:  opt.NotifyHashed,
 		contentHasher: opt.ContentHasher,
 		progressCb:    opt.ProgressCb,
@@ -108,8 +113,10 @@ type receiver struct {
 	conn         Stream
 	files        map[string]uint32
 	pipes        map[uint32]io.WriteCloser
+	hashWaiters  map[uint32]chan hashResult
 	mu           sync.RWMutex
 	muPipes      sync.RWMutex
+	muHash       sync.Mutex
 	progressCb   func(int, bool)
 	merge        bool
 	filter       FilterFunc
@@ -248,6 +255,10 @@ func (r *receiver) run(ctx context.Context) error {
 			switch p.Type {
 			case types.PACKET_ERR:
 				return errors.Errorf("error from sender: %s", p.Data)
+			case types.PACKET_HASH:
+				if err := r.handleHashResponse(p.ID, p.Data); err != nil {
+					return err
+				}
 			case types.PACKET_STAT:
 				if p.Stat == nil {
 					if err := w.update(nil); err != nil {
@@ -281,6 +292,7 @@ func (r *receiver) run(ctx context.Context) error {
 				p.Stat.Path = path
 				p.Stat.Linkname = filepath.FromSlash(p.Stat.Linkname)
 
+				id := i
 				if !metaOnly && fileCanRequestData(os.FileMode(p.Stat.Mode)) {
 					r.mu.Lock()
 					r.files[p.Stat.Path] = i
@@ -289,6 +301,9 @@ func (r *receiver) run(ctx context.Context) error {
 				i++
 
 				cp := &currentPath{path: path, stat: p.Stat}
+				if !metaOnly && r.differ == DiffContent && canContentCheck(p.Stat) {
+					cp.contentHash = r.sourceContentHash(id)
+				}
 				if err := r.orderValidator.HandleChange(ChangeKindAdd, cp.path, &StatInfo{cp.stat}, nil); err != nil {
 					return err
 				}
@@ -432,6 +447,57 @@ func (r *receiver) asyncDataFunc(ctx context.Context, p string, wc io.WriteClose
 	r.muPipes.Lock()
 	delete(r.pipes, id)
 	r.muPipes.Unlock()
+	return nil
+}
+
+type hashResult struct {
+	digest []byte
+}
+
+func (r *receiver) sourceContentHash(id uint32) func(context.Context) ([]byte, error) {
+	return func(ctx context.Context) ([]byte, error) {
+		ch := make(chan hashResult, 1)
+
+		r.muHash.Lock()
+		if _, ok := r.hashWaiters[id]; ok {
+			r.muHash.Unlock()
+			return nil, errors.Errorf("duplicate hash request %d", id)
+		}
+		r.hashWaiters[id] = ch
+		r.muHash.Unlock()
+
+		cleanup := func() {
+			r.muHash.Lock()
+			delete(r.hashWaiters, id)
+			r.muHash.Unlock()
+		}
+
+		if err := r.conn.SendMsg(&types.Packet{Type: types.PACKET_HASH_REQ, ID: id}); err != nil {
+			cleanup()
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			cleanup()
+			return nil, ctx.Err()
+		case res := <-ch:
+			cleanup()
+			return res.digest, nil
+		}
+	}
+}
+
+func (r *receiver) handleHashResponse(id uint32, digest []byte) error {
+	r.muHash.Lock()
+	ch, ok := r.hashWaiters[id]
+	r.muHash.Unlock()
+	if !ok {
+		return nil
+	}
+
+	digestCopy := append([]byte(nil), digest...)
+	ch <- hashResult{digest: digestCopy}
 	return nil
 }
 

--- a/receive_test.go
+++ b/receive_test.go
@@ -350,6 +350,86 @@ func TestCopySimple(t *testing.T) {
 	forEachReceiveDiskWriter(t, testCopySimple)
 }
 
+func TestCopyDiffContent(t *testing.T) {
+	forEachReceiveDiskWriter(t, func(t *testing.T, receive receiveTestFunc) {
+		src, err := tmpDir(changeStream([]string{
+			"ADD foo file bbbb",
+			"ADD same file keep",
+			"ADD meta file data",
+		}))
+		require.NoError(t, err)
+		defer os.RemoveAll(src)
+
+		dest, err := tmpDir(changeStream([]string{
+			"ADD foo file aaaa",
+			"ADD same file keep",
+			"ADD meta file data",
+		}))
+		require.NoError(t, err)
+		defer os.RemoveAll(dest)
+
+		ts := time.Unix(123, 0)
+		require.NoError(t, os.Chtimes(filepath.Join(src, "foo"), ts, ts))
+		require.NoError(t, os.Chtimes(filepath.Join(dest, "foo"), ts, ts))
+		require.NoError(t, os.Chtimes(filepath.Join(src, "same"), ts, ts))
+		require.NoError(t, os.Chtimes(filepath.Join(dest, "same"), ts, ts))
+		require.NoError(t, os.Chtimes(filepath.Join(src, "meta"), ts.Add(time.Second), ts.Add(time.Second)))
+		require.NoError(t, os.Chtimes(filepath.Join(dest, "meta"), ts, ts))
+
+		cwd := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(cwd, "foo"), []byte("bbbb"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(cwd, "same"), []byte("keep"), 0644))
+		oldwd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(cwd))
+		defer func() {
+			require.NoError(t, os.Chdir(oldwd))
+		}()
+
+		fs, err := NewFS(src)
+		require.NoError(t, err)
+
+		notify := newNotificationBuffer()
+		chs := &changes{fn: notify.HandleChange}
+
+		eg, ctx := errgroup.WithContext(context.Background())
+		s1, s2 := sockPairProto(ctx)
+		counter := newPacketCounter(s2)
+
+		eg.Go(func() error {
+			defer s1.(*fakeConnProto).closeSend()
+			return Send(ctx, s1, fs, nil)
+		})
+		eg.Go(func() error {
+			return receive(ctx, counter, dest, ReceiveOpt{
+				Differ:        DiffContent,
+				NotifyHashed:  chs.HandleChange,
+				ContentHasher: simpleSHA256Hasher,
+			})
+		})
+
+		require.NoError(t, eg.Wait())
+
+		dt, err := os.ReadFile(filepath.Join(dest, "foo"))
+		require.NoError(t, err)
+		require.Equal(t, "bbbb", string(dt))
+
+		dt, err = os.ReadFile(filepath.Join(dest, "same"))
+		require.NoError(t, err)
+		require.Equal(t, "keep", string(dt))
+
+		_, ok := chs.c["foo"]
+		require.True(t, ok)
+		_, ok = chs.c["meta"]
+		require.True(t, ok)
+		_, ok = chs.c["same"]
+		require.False(t, ok)
+
+		require.Equal(t, 2, counter.Count(types.PACKET_HASH_REQ))
+		require.Equal(t, 2, counter.Count(types.PACKET_REQ))
+	})
+}
+
 func testCopySimple(t *testing.T, receive receiveTestFunc) {
 	d, err := tmpDir(changeStream([]string{
 		"ADD foo file data1",
@@ -699,6 +779,34 @@ type fakeConnProto struct {
 	ctx      context.Context
 	recvChan chan []byte
 	sendChan chan []byte
+}
+
+type packetCounter struct {
+	Stream
+	mu     sync.Mutex
+	counts map[types.Packet_PacketType]int
+}
+
+func newPacketCounter(s Stream) *packetCounter {
+	return &packetCounter{
+		Stream: s,
+		counts: map[types.Packet_PacketType]int{},
+	}
+}
+
+func (pc *packetCounter) SendMsg(m any) error {
+	if p, ok := m.(*types.Packet); ok {
+		pc.mu.Lock()
+		pc.counts[p.Type]++
+		pc.mu.Unlock()
+	}
+	return pc.Stream.SendMsg(m)
+}
+
+func (pc *packetCounter) Count(t types.Packet_PacketType) int {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.counts[t]
 }
 
 func (fc *fakeConnProto) Context() context.Context {

--- a/send.go
+++ b/send.go
@@ -2,9 +2,11 @@ package fsutil
 
 import (
 	"context"
+	"crypto/sha256"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"syscall"
 
@@ -13,9 +15,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const bufferSize = 32 * 1024
+
 var bufPool = sync.Pool{
 	New: func() any {
-		buf := make([]byte, 32*1<<10)
+		buf := make([]byte, bufferSize)
 		return &buf
 	},
 }
@@ -55,6 +59,7 @@ type sender struct {
 
 func (s *sender) run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
+	hashLimit := make(chan struct{}, hashConcurrency())
 
 	defer s.updateProgress(0, true)
 
@@ -102,6 +107,21 @@ func (s *sender) run(ctx context.Context) error {
 				if err := s.queue(p.ID); err != nil {
 					return err
 				}
+			case types.PACKET_HASH_REQ:
+				path, err := s.lookup(p.ID)
+				if err != nil {
+					return err
+				}
+				h := &sendHandle{p.ID, path}
+				g.Go(func() error {
+					select {
+					case hashLimit <- struct{}{}:
+						defer func() { <-hashLimit }()
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					return s.sendHash(h)
+				})
 			case types.PACKET_FIN:
 				return s.conn.SendMsg(&types.Packet{Type: types.PACKET_FIN})
 			}
@@ -109,6 +129,14 @@ func (s *sender) run(ctx context.Context) error {
 	})
 
 	return g.Wait()
+}
+
+func hashConcurrency() int {
+	n := runtime.GOMAXPROCS(0)
+	if n < 1 {
+		return 1
+	}
+	return n
 }
 
 func (s *sender) updateProgress(size int, last bool) {
@@ -131,6 +159,39 @@ func (s *sender) queue(id uint32) error {
 	s.mu.Unlock()
 	s.sendpipeline <- &sendHandle{id, p}
 	return nil
+}
+
+func (s *sender) lookup(id uint32) (string, error) {
+	s.mu.RLock()
+	p, ok := s.files[id]
+	s.mu.RUnlock()
+	if !ok {
+		return "", errors.Errorf("invalid file id %d", id)
+	}
+	return p, nil
+}
+
+func (s *sender) sendHash(hdl *sendHandle) error {
+	f, err := s.fs.Open(hdl.path)
+	if err != nil {
+		return err
+	}
+
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
+
+	h := sha256.New()
+	if _, err := io.CopyBuffer(h, f, *buf); err != nil {
+		f.Close()
+		return errors.WithStack(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	packet := &types.Packet{ID: hdl.id, Type: types.PACKET_HASH, Data: h.Sum(nil)}
+	s.updateProgress(packet.Size(), false)
+	return s.conn.SendMsg(packet)
 }
 
 func (s *sender) sendFile(h *sendHandle) error {

--- a/types/wire.go
+++ b/types/wire.go
@@ -1,11 +1,13 @@
 package types
 
 const (
-	PACKET_STAT = Packet_PACKET_STAT
-	PACKET_REQ  = Packet_PACKET_REQ
-	PACKET_DATA = Packet_PACKET_DATA
-	PACKET_FIN  = Packet_PACKET_FIN
-	PACKET_ERR  = Packet_PACKET_ERR
+	PACKET_STAT     = Packet_PACKET_STAT
+	PACKET_REQ      = Packet_PACKET_REQ
+	PACKET_DATA     = Packet_PACKET_DATA
+	PACKET_FIN      = Packet_PACKET_FIN
+	PACKET_ERR      = Packet_PACKET_ERR
+	PACKET_HASH_REQ = Packet_PACKET_HASH_REQ
+	PACKET_HASH     = Packet_PACKET_HASH
 )
 
 func (p *Packet) Marshal() ([]byte, error) {

--- a/types/wire.pb.go
+++ b/types/wire.pb.go
@@ -25,11 +25,13 @@ const (
 type Packet_PacketType int32
 
 const (
-	Packet_PACKET_STAT Packet_PacketType = 0
-	Packet_PACKET_REQ  Packet_PacketType = 1
-	Packet_PACKET_DATA Packet_PacketType = 2
-	Packet_PACKET_FIN  Packet_PacketType = 3
-	Packet_PACKET_ERR  Packet_PacketType = 4
+	Packet_PACKET_STAT     Packet_PacketType = 0
+	Packet_PACKET_REQ      Packet_PacketType = 1
+	Packet_PACKET_DATA     Packet_PacketType = 2
+	Packet_PACKET_FIN      Packet_PacketType = 3
+	Packet_PACKET_ERR      Packet_PacketType = 4
+	Packet_PACKET_HASH_REQ Packet_PacketType = 5
+	Packet_PACKET_HASH     Packet_PacketType = 6
 )
 
 // Enum value maps for Packet_PacketType.
@@ -40,13 +42,17 @@ var (
 		2: "PACKET_DATA",
 		3: "PACKET_FIN",
 		4: "PACKET_ERR",
+		5: "PACKET_HASH_REQ",
+		6: "PACKET_HASH",
 	}
 	Packet_PacketType_value = map[string]int32{
-		"PACKET_STAT": 0,
-		"PACKET_REQ":  1,
-		"PACKET_DATA": 2,
-		"PACKET_FIN":  3,
-		"PACKET_ERR":  4,
+		"PACKET_STAT":     0,
+		"PACKET_REQ":      1,
+		"PACKET_DATA":     2,
+		"PACKET_FIN":      3,
+		"PACKET_ERR":      4,
+		"PACKET_HASH_REQ": 5,
+		"PACKET_HASH":     6,
 	}
 )
 
@@ -149,12 +155,12 @@ var File_github_com_tonistiigi_fsutil_types_wire_proto protoreflect.FileDescript
 
 const file_github_com_tonistiigi_fsutil_types_wire_proto_rawDesc = "" +
 	"\n" +
-	"-github.com/tonistiigi/fsutil/types/wire.proto\x12\ffsutil.types\x1a3github.com/planetscale/vtprotobuf/vtproto/ext.proto\x1a-github.com/tonistiigi/fsutil/types/stat.proto\"\xef\x01\n" +
+	"-github.com/tonistiigi/fsutil/types/wire.proto\x12\ffsutil.types\x1a3github.com/planetscale/vtprotobuf/vtproto/ext.proto\x1a-github.com/tonistiigi/fsutil/types/stat.proto\"\x96\x02\n" +
 	"\x06Packet\x123\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1f.fsutil.types.Packet.PacketTypeR\x04type\x12&\n" +
 	"\x04stat\x18\x02 \x01(\v2\x12.fsutil.types.StatR\x04stat\x12\x0e\n" +
 	"\x02ID\x18\x03 \x01(\rR\x02ID\x12\x12\n" +
-	"\x04data\x18\x04 \x01(\fR\x04data\"^\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\"\x84\x01\n" +
 	"\n" +
 	"PacketType\x12\x0f\n" +
 	"\vPACKET_STAT\x10\x00\x12\x0e\n" +
@@ -164,7 +170,9 @@ const file_github_com_tonistiigi_fsutil_types_wire_proto_rawDesc = "" +
 	"\n" +
 	"PACKET_FIN\x10\x03\x12\x0e\n" +
 	"\n" +
-	"PACKET_ERR\x10\x04:\x04\xa8\xa6\x1f\x01B$Z\"github.com/tonistiigi/fsutil/typesb\x06proto3"
+	"PACKET_ERR\x10\x04\x12\x13\n" +
+	"\x0fPACKET_HASH_REQ\x10\x05\x12\x0f\n" +
+	"\vPACKET_HASH\x10\x06:\x04\xa8\xa6\x1f\x01B$Z\"github.com/tonistiigi/fsutil/typesb\x06proto3"
 
 var (
 	file_github_com_tonistiigi_fsutil_types_wire_proto_rawDescOnce sync.Once

--- a/types/wire.proto
+++ b/types/wire.proto
@@ -15,6 +15,8 @@ message Packet {
     PACKET_DATA = 2;
     PACKET_FIN = 3;
     PACKET_ERR = 4;
+    PACKET_HASH_REQ = 5;
+    PACKET_HASH = 6;
   }
   PacketType type = 1;
   Stat stat = 2;


### PR DESCRIPTION
Add PACKET_HASH_REQ/PACKET_HASH to the wire protocol: when metadata
matches, the receiver requests the sender's digest and skips the
transfer when it equals the local digest. Hashing is bounded on both
ends and resolved concurrently after the walk completes.