### PR TITLE
copy: avoid timespec struct conversion

### DIFF
--- a/copy/copy_linux.go
+++ b/copy/copy_linux.go
@@ -62,7 +62,11 @@ func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
 	}
 
 	st := fi.Sys().(*syscall.Stat_t)
-	timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
+	atime, mtime := StatAtime(st), StatMtime(st)
+	timespec := []unix.Timespec{
+		{Sec: atime.Sec, Nsec: atime.Nsec},
+		{Sec: mtime.Sec, Nsec: mtime.Nsec},
+	}
 	if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}

--- a/copy/copy_unix.go
+++ b/copy/copy_unix.go
@@ -62,7 +62,11 @@ func (c *copier) copyFileTimestamp(fi os.FileInfo, name string) error {
 	}
 
 	st := fi.Sys().(*syscall.Stat_t)
-	timespec := []unix.Timespec{unix.Timespec(StatAtime(st)), unix.Timespec(StatMtime(st))}
+	atime, mtime := StatAtime(st), StatMtime(st)
+	timespec := []unix.Timespec{
+		{Sec: atime.Sec, Nsec: atime.Nsec},
+		{Sec: mtime.Sec, Nsec: mtime.Nsec},
+	}
 	if err := unix.UtimesNanoAt(unix.AT_FDCWD, name, timespec, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}


### PR DESCRIPTION
fixes #266 

Fixes a FreeBSD arm build failure when copying file timestamps.

The copy package now constructs `unix.Timespec` values from the exported `Sec` and `Nsec` fields of `syscall.Timespec` instead of relying on direct struct conversion.

FreeBSD on arm includes padding in `syscall.Timespec`, which makes it incompatible with `golang.org/x/sys/unix.Timespec` for direct conversion. Copying the fields preserves the timestamp behavior without depending on platform-specific struct layout.