### PR TITLE
ci: add 32-bit BSD arm cross builds

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,6 +15,7 @@ target "_platforms" {
     "darwin/amd64",
     "darwin/arm64",
     "freebsd/amd64",
+    "freebsd/arm",
     "freebsd/arm64",
     "linux/386",
     "linux/amd64",
@@ -23,8 +24,10 @@ target "_platforms" {
     "linux/ppc64le",
     "linux/s390x",
     "netbsd/amd64",
+    "netbsd/arm",
     "netbsd/arm64",
     "openbsd/amd64",
+    "openbsd/arm",
     "openbsd/arm64",
     "windows/amd64",
     "windows/arm64"


### PR DESCRIPTION
follow-up https://github.com/tonistiigi/fsutil/pull/267#pullrequestreview-4675849041

Add freebsd/arm, netbsd/arm, and openbsd/arm to the cross-build platform list so CI compiles the 32-bit BSD ARM targets. This extends coverage for the syscall and x/sys timestamp layout mismatch that was missed by the existing BSD amd64 and arm64 builds.