### PR TITLE
bench: fs mode matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
         file-size:
           - ""
           - "10000"
+        fs-mode:
+          - "path"
+          - "osroot"
     env:
+      BENCH_FS_MODE: ${{ matrix.fs-mode }}
       BENCH_FILE_SIZE: ${{ matrix.file-size }}
     steps:
       -
@@ -113,7 +117,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           directory: ${{ env.DESTDIR }}/bench
-          flags: bench,${{ matrix.mode }},go-${{ env.GO_VERSION }},file-size-${{ matrix.file-size || 'default' }}
+          flags: bench,${{ matrix.mode }},go-${{ env.GO_VERSION }},file-size-${{ matrix.file-size || 'default' }},fs-mode-${{ matrix.fs-mode }}
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ EOT
 
 FROM bench-base AS bench
 WORKDIR /src
+ARG BENCH_FS_MODE
 ARG BENCH_FILE_SIZE
 RUN --mount=target=. \
     --mount=target=/go/pkg/mod,type=cache \
@@ -67,6 +68,7 @@ FROM bench-base AS bench-noroot
 WORKDIR /src
 RUN mkdir -p /go/pkg && chmod 0777 /go/pkg
 USER 1000:1000
+ARG BENCH_FS_MODE
 ARG BENCH_FILE_SIZE
 RUN --mount=target=. \
     --mount=target=/tmp/.cache,type=cache <<EOT

--- a/bench/diffcopy.go
+++ b/bench/diffcopy.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -17,6 +18,17 @@ type closeableStream interface {
 }
 
 func diffCopy(proto bool, src, dest string) error {
+	switch mode := os.Getenv("BENCH_FS_MODE"); mode {
+	case "", "path":
+		return diffCopyPath(proto, src, dest)
+	case "osroot":
+		return diffCopyRoot(proto, src, dest)
+	default:
+		return errors.Errorf("unsupported BENCH_FS_MODE %q", mode)
+	}
+}
+
+func diffCopyPath(proto bool, src, dest string) error {
 	var s1, s2 closeableStream
 
 	eg, ctx := errgroup.WithContext(context.Background())
@@ -28,11 +40,11 @@ func diffCopy(proto bool, src, dest string) error {
 	}
 
 	eg.Go(func() error {
+		defer s1.Close()
 		fs, err := fsutil.NewFS(src)
 		if err != nil {
-			panic(err)
+			return err
 		}
-		defer s1.Close()
 		return fsutil.Send(ctx, s1, fs, nil)
 	})
 	eg.Go(func() error {
@@ -48,6 +60,41 @@ func diffCopyProto(src, dest string) error {
 }
 func diffCopyReg(src, dest string) error {
 	return diffCopy(false, src, dest)
+}
+
+func diffCopyRoot(proto bool, src, dest string) error {
+	var s1, s2 closeableStream
+
+	eg, ctx := errgroup.WithContext(context.Background())
+
+	if proto {
+		s1, s2 = sockPairProto(ctx)
+	} else {
+		s1, s2 = sockPair(ctx)
+	}
+
+	eg.Go(func() error {
+		defer s1.Close()
+		osroot, err := os.OpenRoot(src)
+		if err != nil {
+			return err
+		}
+		root := fsutil.NewRoot(osroot)
+		defer root.Close()
+		return fsutil.Send(ctx, s1, fsutil.NewRootFS(root), nil)
+	})
+	eg.Go(func() error {
+		defer s2.Close()
+		osroot, err := os.OpenRoot(dest)
+		if err != nil {
+			return err
+		}
+		root := fsutil.NewRoot(osroot)
+		defer root.Close()
+		return fsutil.ReceiveRoot(ctx, s2, root, fsutil.ReceiveOpt{})
+	})
+
+	return eg.Wait()
 }
 
 func sockPair(ctx context.Context) (closeableStream, closeableStream) {

--- a/bench/diffcopy_test.go
+++ b/bench/diffcopy_test.go
@@ -6,11 +6,21 @@ import (
 )
 
 func TestDiffCopyFakeConnEOF(t *testing.T) {
-	for name, fn := range map[string]func(string, string) error{
-		"packet": diffCopyReg,
-		"proto":  diffCopyProto,
+	for _, tc := range []struct {
+		name string
+		mode string
+		fn   func(string, string) error
+	}{
+		{name: "packet_default", fn: diffCopyReg},
+		{name: "proto_default", fn: diffCopyProto},
+		{name: "packet_path", mode: "path", fn: diffCopyReg},
+		{name: "proto_path", mode: "path", fn: diffCopyProto},
+		{name: "packet_osroot", mode: "osroot", fn: diffCopyReg},
+		{name: "proto_osroot", mode: "osroot", fn: diffCopyProto},
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BENCH_FS_MODE", tc.mode)
+
 			src, err := createTestDir(10)
 			if err != nil {
 				t.Fatal(err)
@@ -18,7 +28,7 @@ func TestDiffCopyFakeConnEOF(t *testing.T) {
 			defer os.RemoveAll(src)
 
 			dest := t.TempDir()
-			if err := fn(src, dest); err != nil {
+			if err := tc.fn(src, dest); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,10 @@ variable "BENCH_FILE_SIZE" {
   default = null
 }
 
+variable "BENCH_FS_MODE" {
+  default = null
+}
+
 target "_platforms" {
   platforms = [
     "darwin/amd64",
@@ -73,6 +77,7 @@ target "bench-root" {
   output = ["${DESTDIR}/bench"]
   args = {
     BENCH_FILE_SIZE = BENCH_FILE_SIZE
+    BENCH_FS_MODE = BENCH_FS_MODE
   }
 }
 
@@ -82,6 +87,7 @@ target "bench-noroot" {
   output = ["${DESTDIR}/bench"]
   args = {
     BENCH_FILE_SIZE = BENCH_FILE_SIZE
+    BENCH_FS_MODE = BENCH_FS_MODE
   }
 }
 


### PR DESCRIPTION
This adds a benchmark matrix dimension for selecting the filesystem mode used by diffcopy benchmarks.

The benchmark workflow now runs both `path` and `osroot` filesystem modes. The diffcopy benchmark helper uses that mode to choose between the existing path-based filesystem path and the `os.Root` based filesystem path.

This makes it possible to compare the existing path implementation against the `os.Root` implementation in the same benchmark matrix without switching commits or adding benchmark-specific selectors.

As follow-up we should look at running benchmarks on the same runner for accurate results instead of distributing them.