### PR TITLE
bench: add fs mode sub-benchmarks

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -192,55 +192,87 @@ func BenchmarkCPA1000(b *testing.B) {
 }
 
 func BenchmarkDiffCopy10(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyReg, 10)
+	benchmarkInitialDiffCopy(b, false, 10)
 }
 
 func BenchmarkDiffCopy50(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyReg, 50)
+	benchmarkInitialDiffCopy(b, false, 50)
 }
 
 func BenchmarkDiffCopy200(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyReg, 200)
+	benchmarkInitialDiffCopy(b, false, 200)
 }
 
 func BenchmarkDiffCopy1000(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyReg, 1000)
+	benchmarkInitialDiffCopy(b, false, 1000)
 }
 
 func BenchmarkDiffCopyProto10(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyProto, 10)
+	benchmarkInitialDiffCopy(b, true, 10)
 }
 
 func BenchmarkDiffCopyProto50(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyProto, 50)
+	benchmarkInitialDiffCopy(b, true, 50)
 }
 
 func BenchmarkDiffCopyProto200(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyProto, 200)
+	benchmarkInitialDiffCopy(b, true, 200)
 }
 
 func BenchmarkDiffCopyProto1000(b *testing.B) {
-	benchmarkInitialCopy(b, diffCopyProto, 1000)
+	benchmarkInitialDiffCopy(b, true, 1000)
 }
 
 func BenchmarkIncrementalDiffCopy10(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 10)
+	benchmarkIncrementalDiffCopy(b, 10)
 }
 func BenchmarkIncrementalDiffCopy50(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 50)
+	benchmarkIncrementalDiffCopy(b, 50)
 }
 func BenchmarkIncrementalDiffCopy200(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 200)
+	benchmarkIncrementalDiffCopy(b, 200)
 }
 func BenchmarkIncrementalDiffCopy1000(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 1000)
+	benchmarkIncrementalDiffCopy(b, 1000)
 }
 
 func BenchmarkIncrementalDiffCopy5000(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 5000)
+	benchmarkIncrementalDiffCopy(b, 5000)
 }
 func BenchmarkIncrementalDiffCopy10000(b *testing.B) {
-	benchmarkIncrementalCopy(b, diffCopyReg, 10000)
+	benchmarkIncrementalDiffCopy(b, 10000)
+}
+
+type diffCopyMode struct {
+	name string
+	fn   func(bool, string, string) error
+}
+
+var diffCopyModes = []diffCopyMode{
+	{name: "path", fn: diffCopyPath},
+	{name: "osroot", fn: diffCopyRoot},
+}
+
+func benchmarkInitialDiffCopy(b *testing.B, proto bool, size int) {
+	for _, mode := range diffCopyModes {
+		b.Run(mode.name, func(b *testing.B) {
+			benchmarkInitialCopy(b, mode.transfer(proto), size)
+		})
+	}
+}
+
+func benchmarkIncrementalDiffCopy(b *testing.B, size int) {
+	for _, mode := range diffCopyModes {
+		b.Run(mode.name, func(b *testing.B) {
+			benchmarkIncrementalCopy(b, mode.transfer(false), size)
+		})
+	}
+}
+
+func (m diffCopyMode) transfer(proto bool) func(string, string) error {
+	return func(src, dest string) error {
+		return m.fn(proto, src, dest)
+	}
 }
 
 func BenchmarkIncrementalCopyWithTar10(b *testing.B) {

--- a/bench/diffcopy.go
+++ b/bench/diffcopy.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -17,6 +18,10 @@ type closeableStream interface {
 }
 
 func diffCopy(proto bool, src, dest string) error {
+	return diffCopyPath(proto, src, dest)
+}
+
+func diffCopyPath(proto bool, src, dest string) error {
 	var s1, s2 closeableStream
 
 	eg, ctx := errgroup.WithContext(context.Background())
@@ -28,11 +33,11 @@ func diffCopy(proto bool, src, dest string) error {
 	}
 
 	eg.Go(func() error {
+		defer s1.Close()
 		fs, err := fsutil.NewFS(src)
 		if err != nil {
-			panic(err)
+			return err
 		}
-		defer s1.Close()
 		return fsutil.Send(ctx, s1, fs, nil)
 	})
 	eg.Go(func() error {
@@ -48,6 +53,41 @@ func diffCopyProto(src, dest string) error {
 }
 func diffCopyReg(src, dest string) error {
 	return diffCopy(false, src, dest)
+}
+
+func diffCopyRoot(proto bool, src, dest string) error {
+	var s1, s2 closeableStream
+
+	eg, ctx := errgroup.WithContext(context.Background())
+
+	if proto {
+		s1, s2 = sockPairProto(ctx)
+	} else {
+		s1, s2 = sockPair(ctx)
+	}
+
+	eg.Go(func() error {
+		defer s1.Close()
+		osroot, err := os.OpenRoot(src)
+		if err != nil {
+			return err
+		}
+		root := fsutil.NewRoot(osroot)
+		defer root.Close()
+		return fsutil.Send(ctx, s1, fsutil.NewRootFS(root), nil)
+	})
+	eg.Go(func() error {
+		defer s2.Close()
+		osroot, err := os.OpenRoot(dest)
+		if err != nil {
+			return err
+		}
+		root := fsutil.NewRoot(osroot)
+		defer root.Close()
+		return fsutil.ReceiveRoot(ctx, s2, root, fsutil.ReceiveOpt{})
+	})
+
+	return eg.Wait()
 }
 
 func sockPair(ctx context.Context) (closeableStream, closeableStream) {

--- a/bench/diffcopy_test.go
+++ b/bench/diffcopy_test.go
@@ -6,11 +6,18 @@ import (
 )
 
 func TestDiffCopyFakeConnEOF(t *testing.T) {
-	for name, fn := range map[string]func(string, string) error{
-		"packet": diffCopyReg,
-		"proto":  diffCopyProto,
+	for _, tc := range []struct {
+		name string
+		fn   func(string, string) error
+	}{
+		{name: "packet_default", fn: diffCopyReg},
+		{name: "proto_default", fn: diffCopyProto},
+		{name: "packet_path", fn: func(src, dest string) error { return diffCopyPath(false, src, dest) }},
+		{name: "proto_path", fn: func(src, dest string) error { return diffCopyPath(true, src, dest) }},
+		{name: "packet_osroot", fn: func(src, dest string) error { return diffCopyRoot(false, src, dest) }},
+		{name: "proto_osroot", fn: func(src, dest string) error { return diffCopyRoot(true, src, dest) }},
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			src, err := createTestDir(10)
 			if err != nil {
 				t.Fatal(err)
@@ -18,7 +25,7 @@ func TestDiffCopyFakeConnEOF(t *testing.T) {
 			defer os.RemoveAll(src)
 
 			dest := t.TempDir()
-			if err := fn(src, dest); err != nil {
+			if err := tc.fn(src, dest); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
alternative to and closes https://github.com/tonistiigi/fsutil/pull/273

Add os.Root-backed diffcopy benchmarks alongside the existing path-backed implementation.

Run the path and osroot modes as Go sub-benchmarks so CI keeps the same runner matrix while benchmark output still separates the filesystem mode.