### PR TITLE
tarwriter: walk fs root portably

### DIFF
--- a/tarwriter.go
+++ b/tarwriter.go
@@ -15,7 +15,7 @@ import (
 
 func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	err := fs.Walk(ctx, "/", func(path string, entry os.DirEntry, err error) error {
+	err := fs.Walk(ctx, "", func(path string, entry os.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -33,6 +33,7 @@ func WriteTar(ctx context.Context, fs FS, w io.Writer) error {
 			return err
 		}
 
+		// Tar paths use slash separators on the wire.
 		name := filepath.ToSlash(path)
 		if fi.IsDir() && !strings.HasSuffix(name, "/") {
 			name += "/"

--- a/tarwriter_test.go
+++ b/tarwriter_test.go
@@ -1,0 +1,65 @@
+package fsutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func TestWriteTarSubDirFSRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	apply := fstest.Apply(
+		fstest.CreateFile("payload.txt", []byte("payload"), 0600),
+	)
+	require.NoError(t, apply.Apply(tmpDir))
+
+	tmpFS, err := NewFS(tmpDir)
+	require.NoError(t, err)
+
+	f, err := SubDirFS([]Dir{
+		{
+			Stat: &types.Stat{
+				Mode: uint32(os.ModeDir | 0755),
+				Path: ".._buildkit-outside",
+			},
+			FS: tmpFS,
+		},
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteTar(context.TODO(), f, &buf))
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	expected := ".._buildkit-outside/payload.txt"
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+
+		// The tar can contain directory entries and unrelated files; this test
+		// only verifies that the payload is exported under the sanitized root.
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if hdr.Name != expected {
+			continue
+		}
+		dt, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		require.Equal(t, []byte("payload"), dt)
+		return
+	}
+
+	require.Failf(t, "expected payload", "expected payload under %q", expected)
+}


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/pull/7022

Tar output now walks the filesystem root in a way that works consistently across platforms before writing slash-separated tar paths. This fixes Windows cases where tar exports built from grouped filesystem views could miss files, including the failure seen while validating https://github.com/moby/buildkit/pull/7022.