### PR TITLE
use root entries for async writes

### DIFF
--- a/root_entry.go
+++ b/root_entry.go
@@ -1,0 +1,126 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// RootEntry is an opened parent directory and final path component for a
+// root-relative path.
+//
+// The parent file is owned by RootEntry. Callers must not close it directly.
+type RootEntry struct {
+	root        Root
+	path        string
+	base        string
+	parent      *os.File
+	closeParent bool
+	closed      bool
+}
+
+type rootEntryOpener interface {
+	openRootEntry(string) (*RootEntry, error)
+}
+
+// OpenRootEntry opens the parent directory for name within root and returns an
+// entry object for operations on name's final path component.
+func OpenRootEntry(root Root, name string) (*RootEntry, error) {
+	if root == nil {
+		return nil, errors.New("nil root")
+	}
+	if opener, ok := root.(rootEntryOpener); ok {
+		return opener.openRootEntry(name)
+	}
+	return openRootEntryFallback(root, name)
+}
+
+func openRootEntryFallback(root Root, name string) (*RootEntry, error) {
+	path, dir, base, err := cleanRootEntryPath(name)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := root.OpenFile(dir, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if fi, err := parent.Stat(); err != nil {
+		parent.Close()
+		return nil, errors.WithStack(err)
+	} else if !fi.IsDir() {
+		parent.Close()
+		return nil, errors.WithStack(&os.PathError{Op: "openat", Path: name, Err: syscall.ENOTDIR})
+	}
+	return &RootEntry{
+		root:        root,
+		path:        path,
+		base:        base,
+		parent:      parent,
+		closeParent: true,
+	}, nil
+}
+
+func cleanRootEntryPath(name string) (path, dir, base string, err error) {
+	if name == "" || name == "." || name == ".." || filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+		return "", "", "", errors.WithStack(&os.PathError{Op: "openat", Path: name, Err: syscall.EINVAL})
+	}
+
+	path = filepath.Clean(name)
+	if path == "." || path == ".." || strings.HasPrefix(path, ".."+string(filepath.Separator)) {
+		return "", "", "", errors.WithStack(&os.PathError{Op: "openat", Path: name, Err: syscall.EINVAL})
+	}
+	base = filepath.Base(path)
+	if base == "." || base == ".." || base == string(filepath.Separator) || base == "" {
+		return "", "", "", errors.WithStack(&os.PathError{Op: "openat", Path: name, Err: syscall.EINVAL})
+	}
+	dir = filepath.Dir(path)
+	return path, dir, base, nil
+}
+
+// Path returns the cleaned root-relative path for the entry.
+func (e *RootEntry) Path() string {
+	if e == nil {
+		return ""
+	}
+	return e.path
+}
+
+// Base returns the final path component for the entry.
+func (e *RootEntry) Base() string {
+	if e == nil {
+		return ""
+	}
+	return e.base
+}
+
+// Parent returns the opened parent directory for the entry.
+//
+// The returned file is owned by the RootEntry and must not be closed by the
+// caller.
+func (e *RootEntry) Parent() (*os.File, error) {
+	if e == nil || e.closed || e.parent == nil {
+		return nil, errors.WithStack(os.ErrClosed)
+	}
+	return e.parent, nil
+}
+
+// Close releases resources held by the entry.
+func (e *RootEntry) Close() error {
+	if e == nil || e.closed {
+		return nil
+	}
+	e.closed = true
+	if !e.closeParent || e.parent == nil {
+		e.parent = nil
+		return nil
+	}
+	err := e.parent.Close()
+	e.parent = nil
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/root_entry_mknod_freebsd.go
+++ b/root_entry_mknod_freebsd.go
@@ -1,0 +1,22 @@
+//go:build freebsd
+
+package fsutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates the entry as a device node or FIFO.
+func (e *RootEntry) Mknod(mode uint32, dev int) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Mknodat(int(parent.Fd()), e.base, mode, uint64(dev)); err != nil {
+		return errors.WithStack(&os.PathError{Op: "mknodat", Path: e.path, Err: err})
+	}
+	return nil
+}

--- a/root_entry_mknod_unix.go
+++ b/root_entry_mknod_unix.go
@@ -1,0 +1,22 @@
+//go:build linux || netbsd || openbsd || dragonfly
+
+package fsutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// Mknod creates the entry as a device node or FIFO.
+func (e *RootEntry) Mknod(mode uint32, dev int) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Mknodat(int(parent.Fd()), e.base, mode, dev); err != nil {
+		return errors.WithStack(&os.PathError{Op: "mknodat", Path: e.path, Err: err})
+	}
+	return nil
+}

--- a/root_entry_mknod_unix_test.go
+++ b/root_entry_mknod_unix_test.go
@@ -1,0 +1,32 @@
+//go:build linux || freebsd || netbsd || openbsd || dragonfly
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootEntryMknodFIFO(t *testing.T) {
+	dest := t.TempDir()
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	entry, err := OpenRootEntry(destRoot, "fifo")
+	require.NoError(t, err)
+	defer entry.Close()
+
+	require.NoError(t, entry.Mknod(syscall.S_IFIFO|0600, 0))
+
+	fi, err := os.Lstat(filepath.Join(dest, "fifo"))
+	require.NoError(t, err)
+	require.NotZero(t, fi.Mode()&os.ModeNamedPipe)
+	require.Equal(t, os.FileMode(0600), fi.Mode().Perm())
+}

--- a/root_entry_mknod_unsupported.go
+++ b/root_entry_mknod_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !freebsd && !netbsd && !openbsd && !dragonfly
+
+package fsutil
+
+import "syscall"
+
+// Mknod creates the entry as a device node or FIFO.
+func (e *RootEntry) Mknod(mode uint32, dev int) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return unsupportedRootOp("mknodat", e.path, syscall.ENOSYS)
+}

--- a/root_entry_test.go
+++ b/root_entry_test.go
@@ -1,0 +1,88 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenRootEntryMkdir(t *testing.T) {
+	dest := t.TempDir()
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	require.NoError(t, destRoot.Mkdir("parent", 0700))
+
+	entry, err := OpenRootEntry(destRoot, filepath.Join("parent", "child"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("parent", "child"), entry.Path())
+	require.Equal(t, "child", entry.Base())
+	require.NoError(t, entry.Mkdir(0750))
+	require.NoError(t, entry.Close())
+
+	fi, err := os.Lstat(filepath.Join(dest, "parent", "child"))
+	require.NoError(t, err)
+	require.True(t, fi.IsDir())
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0750), fi.Mode().Perm())
+	}
+
+	_, err = entry.Parent()
+	require.ErrorIs(t, err, os.ErrClosed)
+}
+
+type fallbackRootEntryRoot struct {
+	Root
+}
+
+func TestOpenRootEntryFallback(t *testing.T) {
+	dest := t.TempDir()
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := fallbackRootEntryRoot{Root: NewRoot(osroot)}
+	defer destRoot.Close()
+
+	require.NoError(t, destRoot.Mkdir("parent", 0700))
+
+	entry, err := OpenRootEntry(destRoot, filepath.Join("parent", "child"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("parent", "child"), entry.Path())
+	require.Equal(t, "child", entry.Base())
+	require.NoError(t, entry.Close())
+}
+
+func TestOpenRootEntryRejectsInvalidName(t *testing.T) {
+	dest := t.TempDir()
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	names := []string{
+		"",
+		".",
+		"..",
+		filepath.Join("dir", ".."),
+		filepath.Join("dir", "..", "..", "file"),
+		filepath.VolumeName(dest) + string(filepath.Separator),
+	}
+	if volume := filepath.VolumeName(dest); volume != "" {
+		names = append(names, volume+"file")
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			entry, err := OpenRootEntry(destRoot, name)
+			require.Error(t, err)
+			require.Nil(t, entry)
+		})
+	}
+}

--- a/root_entry_unix.go
+++ b/root_entry_unix.go
@@ -1,0 +1,127 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package fsutil
+
+import (
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func (r *root) openRootEntry(name string) (*RootEntry, error) {
+	path, _, _, err := cleanRootEntryPath(name)
+	if err != nil {
+		return nil, err
+	}
+	parent, base, closeParent, err := r.openRootParent(path)
+	if err != nil {
+		return nil, err
+	}
+	return &RootEntry{
+		root:        r,
+		path:        path,
+		base:        base,
+		parent:      parent,
+		closeParent: closeParent,
+	}, nil
+}
+
+// OpenFileNoFollow opens the entry without following a final symlink.
+func (e *RootEntry) OpenFileNoFollow(flag int, perm os.FileMode) (*os.File, error) {
+	if perm&0o777 != perm {
+		return nil, errors.WithStack(&os.PathError{Op: "openat", Path: e.path, Err: errors.New("unsupported file mode")})
+	}
+	parent, err := e.Parent()
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Openat(int(parent.Fd()), e.base, flag|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(perm))
+	if err != nil {
+		return nil, errors.WithStack(&os.PathError{Op: "openat", Path: e.path, Err: err})
+	}
+	return os.NewFile(uintptr(fd), e.path), nil
+}
+
+// Mkdir creates the entry as a directory.
+func (e *RootEntry) Mkdir(mode os.FileMode) error {
+	if mode&0o777 != mode {
+		return errors.WithStack(&os.PathError{Op: "mkdirat", Path: e.path, Err: errors.New("unsupported file mode")})
+	}
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Mkdirat(int(parent.Fd()), e.base, uint32(mode)); err != nil {
+		return errors.WithStack(&os.PathError{Op: "mkdirat", Path: e.path, Err: err})
+	}
+	return nil
+}
+
+// Symlink creates the entry as a symlink to target.
+func (e *RootEntry) Symlink(target string) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Symlinkat(target, int(parent.Fd()), e.base); err != nil {
+		return errors.WithStack(&os.PathError{Op: "symlinkat", Path: e.path, Err: err})
+	}
+	return nil
+}
+
+// Lchown changes ownership of the entry without following a final symlink.
+func (e *RootEntry) Lchown(uid, gid int) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchownat(int(parent.Fd()), e.base, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.WithStack(&os.PathError{Op: "fchownat", Path: e.path, Err: err})
+	}
+	return nil
+}
+
+// ChmodNoFollow changes mode without following a final symlink.
+func (e *RootEntry) ChmodNoFollow(mode os.FileMode) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchmodat(int(parent.Fd()), e.base, rootEntryPerm(mode), unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.WithStack(&os.PathError{Op: "fchmodat", Path: e.path, Err: err})
+	}
+	return nil
+}
+
+// ChtimesNoFollow changes access and modification times without following a
+// final symlink.
+func (e *RootEntry) ChtimesNoFollow(atime, mtime time.Time) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	times := []unix.Timespec{
+		unix.NsecToTimespec(atime.UnixNano()),
+		unix.NsecToTimespec(mtime.UnixNano()),
+	}
+	if err := unix.UtimesNanoAt(int(parent.Fd()), e.base, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return errors.WithStack(&os.PathError{Op: "utimensat", Path: e.path, Err: err})
+	}
+	return nil
+}
+
+func rootEntryPerm(mode os.FileMode) uint32 {
+	perm := uint32(mode.Perm())
+	if mode&os.ModeSetuid != 0 {
+		perm |= unix.S_ISUID
+	}
+	if mode&os.ModeSetgid != 0 {
+		perm |= unix.S_ISGID
+	}
+	if mode&os.ModeSticky != 0 {
+		perm |= unix.S_ISVTX
+	}
+	return perm
+}

--- a/root_entry_unix_test.go
+++ b/root_entry_unix_test.go
@@ -1,0 +1,69 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootEntryOpenFileNoFollowRejectsFinalSymlink(t *testing.T) {
+	dest := t.TempDir()
+	target := filepath.Join(dest, "target")
+	require.NoError(t, os.WriteFile(target, []byte("target"), 0600))
+	require.NoError(t, os.Symlink("target", filepath.Join(dest, "link")))
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	entry, err := OpenRootEntry(destRoot, "link")
+	require.NoError(t, err)
+	defer entry.Close()
+
+	file, err := entry.OpenFileNoFollow(os.O_WRONLY|os.O_TRUNC, 0)
+	if file != nil {
+		require.NoError(t, file.Close())
+	}
+	require.Error(t, err)
+
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, []byte("target"), data)
+}
+
+func TestRootEntryChtimesNoFollowDoesNotFollowSymlink(t *testing.T) {
+	dest := t.TempDir()
+	target := filepath.Join(dest, "target")
+	link := filepath.Join(dest, "link")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0600))
+	require.NoError(t, os.Symlink("target", link))
+
+	targetTime := time.Unix(1000, 0)
+	linkTime := time.Unix(2000, 0)
+	require.NoError(t, os.Chtimes(target, targetTime, targetTime))
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	entry, err := OpenRootEntry(destRoot, "link")
+	require.NoError(t, err)
+	defer entry.Close()
+
+	require.NoError(t, entry.ChtimesNoFollow(linkTime, linkTime))
+
+	linkFi, err := os.Lstat(link)
+	require.NoError(t, err)
+	require.Equal(t, linkTime, linkFi.ModTime())
+
+	targetFi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, targetTime, targetFi.ModTime())
+}

--- a/root_entry_unsupported.go
+++ b/root_entry_unsupported.go
@@ -1,0 +1,51 @@
+//go:build !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly
+
+package fsutil
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func (e *RootEntry) OpenFileNoFollow(flag int, perm os.FileMode) (*os.File, error) {
+	if _, err := e.Parent(); err != nil {
+		return nil, err
+	}
+	return nil, unsupportedRootOp("openat", e.path, syscall.ENOSYS)
+}
+
+func (e *RootEntry) Mkdir(mode os.FileMode) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return e.root.Mkdir(e.path, mode)
+}
+
+func (e *RootEntry) Symlink(target string) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return e.root.Symlink(target, e.path)
+}
+
+func (e *RootEntry) Lchown(uid, gid int) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return e.root.Lchown(e.path, uid, gid)
+}
+
+func (e *RootEntry) ChmodNoFollow(mode os.FileMode) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return unsupportedRootOp("fchmodat", e.path, syscall.ENOSYS)
+}
+
+func (e *RootEntry) ChtimesNoFollow(atime, mtime time.Time) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return unsupportedRootOp("utimensat", e.path, syscall.ENOSYS)
+}

--- a/root_entry_xattr_linux.go
+++ b/root_entry_xattr_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// LSetxattr sets an xattr on the entry without following a final symlink.
+func (e *RootEntry) LSetxattr(key string, value []byte, flags int) error {
+	parent, err := e.Parent()
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/proc/self/fd/%d/%s", parent.Fd(), e.base)
+	if err := unix.Lsetxattr(path, key, value, flags); err != nil {
+		return errors.WithStack(&os.PathError{Op: "lsetxattr", Path: e.path, Err: err})
+	}
+	return nil
+}

--- a/root_entry_xattr_supported.go
+++ b/root_entry_xattr_supported.go
@@ -1,0 +1,24 @@
+//go:build darwin || freebsd || netbsd
+
+package fsutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// LSetxattr sets an xattr on the entry without following a final symlink.
+func (e *RootEntry) LSetxattr(key string, value []byte, flags int) error {
+	f, err := e.OpenFileNoFollow(os.O_RDONLY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := unix.Fsetxattr(int(f.Fd()), key, value, flags); err != nil {
+		return errors.WithStack(&os.PathError{Op: "fsetxattr", Path: e.path, Err: err})
+	}
+	return nil
+}

--- a/root_entry_xattr_test.go
+++ b/root_entry_xattr_test.go
@@ -1,0 +1,37 @@
+//go:build linux || darwin || freebsd || netbsd
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestRootEntryLSetxattr(t *testing.T) {
+	dest := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "file"), []byte("data"), 0600))
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	entry, err := OpenRootEntry(destRoot, "file")
+	require.NoError(t, err)
+	defer entry.Close()
+
+	key := "user.fsutil.rootentry"
+	value := []byte("value")
+	err = entry.LSetxattr(key, value, 0)
+	skipUnsupportedXattr(t, err)
+	require.NoError(t, err)
+
+	buf := make([]byte, len(value))
+	n, err := unix.Getxattr(filepath.Join(dest, "file"), key, buf)
+	require.NoError(t, err)
+	require.Equal(t, value, buf[:n])
+}

--- a/root_entry_xattr_unsupported.go
+++ b/root_entry_xattr_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !freebsd && !netbsd
+
+package fsutil
+
+import "syscall"
+
+// LSetxattr sets an xattr on the entry without following a final symlink.
+func (e *RootEntry) LSetxattr(key string, value []byte, flags int) error {
+	if _, err := e.Parent(); err != nil {
+		return err
+	}
+	return unsupportedRootOp("lsetxattr", e.path, syscall.ENOSYS)
+}

--- a/root_mknod_freebsd.go
+++ b/root_mknod_freebsd.go
@@ -2,26 +2,13 @@
 
 package fsutil
 
-import (
-	"os"
-
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
-)
-
 var _ RootMknod = (*root)(nil)
 
 func (r *root) Mknod(name string, mode uint32, dev int) error {
-	parent, base, closeParent, err := r.openRootParent(name)
+	entry, err := OpenRootEntry(r, name)
 	if err != nil {
 		return err
 	}
-	if closeParent {
-		defer parent.Close()
-	}
-
-	if err := unix.Mknodat(int(parent.Fd()), base, mode, uint64(dev)); err != nil {
-		return errors.WithStack(&os.PathError{Op: "mknodat", Path: name, Err: err})
-	}
-	return nil
+	defer entry.Close()
+	return entry.Mknod(mode, dev)
 }

--- a/root_mknod_unix.go
+++ b/root_mknod_unix.go
@@ -2,26 +2,13 @@
 
 package fsutil
 
-import (
-	"os"
-
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
-)
-
 var _ RootMknod = (*root)(nil)
 
 func (r *root) Mknod(name string, mode uint32, dev int) error {
-	parent, base, closeParent, err := r.openRootParent(name)
+	entry, err := OpenRootEntry(r, name)
 	if err != nil {
 		return err
 	}
-	if closeParent {
-		defer parent.Close()
-	}
-
-	if err := unix.Mknodat(int(parent.Fd()), base, mode, dev); err != nil {
-		return errors.WithStack(&os.PathError{Op: "mknodat", Path: name, Err: err})
-	}
-	return nil
+	defer entry.Close()
+	return entry.Mknod(mode, dev)
 }

--- a/root_parent_unix.go
+++ b/root_parent_unix.go
@@ -16,20 +16,12 @@ import (
 var _ RootLChtimes = (*root)(nil)
 
 func (r *root) LChtimes(name string, mtime time.Time) error {
-	parent, base, closeParent, err := r.openRootParent(name)
+	entry, err := OpenRootEntry(r, name)
 	if err != nil {
 		return err
 	}
-	if closeParent {
-		defer parent.Close()
-	}
-
-	ts := unix.NsecToTimespec(mtime.UnixNano())
-	times := []unix.Timespec{ts, ts}
-	if err := unix.UtimesNanoAt(int(parent.Fd()), base, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-		return errors.WithStack(&os.PathError{Op: "utimensat", Path: name, Err: err})
-	}
-	return nil
+	defer entry.Close()
+	return entry.ChtimesNoFollow(mtime, mtime)
 }
 
 func (r *root) openRootParent(name string) (*os.File, string, bool, error) {

--- a/root_special_unix.go
+++ b/root_special_unix.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tonistiigi/fsutil/types"
 )
 
-func handleRootTarTypeBlockCharFifo(root RootMknod, path string, stat *types.Stat) error {
+func handleRootTarTypeBlockCharFifo(entry *RootEntry, stat *types.Stat) error {
 	mode := uint32(stat.Mode & 07777)
 	if os.FileMode(stat.Mode)&os.ModeCharDevice != 0 {
 		mode |= syscall.S_IFCHR
@@ -19,5 +19,5 @@ func handleRootTarTypeBlockCharFifo(root RootMknod, path string, stat *types.Sta
 		mode |= syscall.S_IFBLK
 	}
 
-	return root.Mknod(path, mode, int(mkdev(stat.Devmajor, stat.Devminor)))
+	return entry.Mknod(mode, int(mkdev(stat.Devmajor, stat.Devminor)))
 }

--- a/root_special_unsupported.go
+++ b/root_special_unsupported.go
@@ -7,6 +7,6 @@ import (
 	"github.com/tonistiigi/fsutil/types"
 )
 
-func handleRootTarTypeBlockCharFifo(RootMknod, string, *types.Stat) error {
+func handleRootTarTypeBlockCharFifo(*RootEntry, *types.Stat) error {
 	return errors.New("not implemented")
 }

--- a/root_xattr.go
+++ b/root_xattr.go
@@ -2,24 +2,13 @@
 
 package fsutil
 
-import (
-	"os"
-
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
-)
-
 var _ RootXattr = (*root)(nil)
 
 func (r *root) LSetxattr(name, key string, value []byte, flags int) error {
-	f, err := r.OpenFile(name, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	entry, err := OpenRootEntry(r, name)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
-	defer f.Close()
-
-	if err := unix.Fsetxattr(int(f.Fd()), key, value, flags); err != nil {
-		return errors.WithStack(&os.PathError{Op: "fsetxattr", Path: name, Err: err})
-	}
-	return nil
+	defer entry.Close()
+	return entry.LSetxattr(key, value, flags)
 }

--- a/rootdiskwriter.go
+++ b/rootdiskwriter.go
@@ -147,7 +147,12 @@ func (dw *RootDiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo
 	}
 
 	if oldFi != nil && fi.IsDir() && oldFi.IsDir() {
-		if err := rewriteRootMetadata(destRoot, base, statCopy); err != nil {
+		entry, err := OpenRootEntry(destRoot, base)
+		if err != nil {
+			return err
+		}
+		defer entry.Close()
+		if err := rewriteRootEntryMetadata(entry, statCopy); err != nil {
 			return errors.Wrapf(err, "error setting dir metadata for %s", destPath)
 		}
 		return nil
@@ -158,11 +163,17 @@ func (dw *RootDiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo
 		newPath = ".tmp." + nextSuffix()
 	}
 
+	entry, err := OpenRootEntry(destRoot, newPath)
+	if err != nil {
+		return err
+	}
+	defer entry.Close()
+
 	isRegularFile := false
 
 	switch {
 	case fi.IsDir():
-		if err := destRoot.Mkdir(newPath, fi.Mode().Perm()); err != nil {
+		if err := entry.Mkdir(fi.Mode().Perm()); err != nil {
 			if errors.Is(err, syscall.EEXIST) {
 				// we saw a race to create this directory, so try again
 				return dw.HandleChange(kind, p, fi, nil)
@@ -171,11 +182,11 @@ func (dw *RootDiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo
 		}
 		dw.dirModTimes[filepath.ToSlash(destPath)] = statCopy.ModTime
 	case fi.Mode()&os.ModeDevice != 0 || fi.Mode()&os.ModeNamedPipe != 0:
-		if err := handleRootTarTypeBlockCharFifo(destRoot, newPath, statCopy); err != nil {
+		if err := handleRootTarTypeBlockCharFifo(entry, statCopy); err != nil {
 			return errors.Wrapf(err, "failed to create device %s", newPath)
 		}
 	case fi.Mode()&os.ModeSymlink != 0:
-		if err := destRoot.Symlink(statCopy.Linkname, newPath); err != nil {
+		if err := entry.Symlink(statCopy.Linkname); err != nil {
 			return errors.Wrapf(err, "failed to symlink %s", newPath)
 		}
 	case statCopy.Linkname != "":
@@ -188,7 +199,7 @@ func (dw *RootDiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo
 		}
 	default:
 		isRegularFile = true
-		file, err := destRoot.OpenFile(newPath, os.O_CREATE|os.O_WRONLY, fi.Mode().Perm())
+		file, err := openRootEntryFile(entry, fi.Mode().Perm())
 		if err != nil {
 			return errors.Wrapf(err, "failed to create %s", newPath)
 		}
@@ -203,7 +214,7 @@ func (dw *RootDiskWriter) HandleChange(kind ChangeKind, p string, fi os.FileInfo
 		}
 	}
 
-	if err := rewriteRootMetadata(destRoot, newPath, statCopy); err != nil {
+	if err := rewriteRootEntryMetadata(entry, statCopy); err != nil {
 		return errors.Wrapf(err, "error setting metadata for %s", newPath)
 	}
 

--- a/rootdiskwriter.go
+++ b/rootdiskwriter.go
@@ -250,12 +250,18 @@ func (dw *RootDiskWriter) requestAsyncFileData(p, dest string, fi os.FileInfo, s
 		}
 		defer lease.Release()
 
-		w := &rootLazyFileWriter{lease: lease}
+		entry, err := OpenRootEntry(lease.root, lease.base)
+		if err != nil {
+			return err
+		}
+		defer entry.Close()
+
+		w := &rootLazyFileWriter{entry: entry}
 		if err := dw.processChange(dw.egCtx, ChangeKindAdd, p, fi, w); err != nil {
 			w.Close()
 			return err
 		}
-		return rootChtimes(lease.root, lease.base, st.ModTime) // TODO: parent dirs
+		return chtimesRootEntry(entry, st.ModTime) // TODO: parent dirs
 	})
 }
 
@@ -304,7 +310,7 @@ func rootChtimes(root Root, p string, un int64) error {
 }
 
 type rootLazyFileWriter struct {
-	lease    *rootLease
+	entry    *RootEntry
 	f        *os.File
 	fileMode *os.FileMode
 	closed   bool
@@ -312,21 +318,21 @@ type rootLazyFileWriter struct {
 
 func (lfw *rootLazyFileWriter) Write(dt []byte) (int, error) {
 	if lfw.f == nil {
-		file, err := lfw.lease.root.OpenFile(lfw.lease.base, os.O_WRONLY, 0)
+		file, err := openRootEntryWriteFile(lfw.entry)
 		if os.IsPermission(err) {
 			// retry after chmod
-			fi, er := lfw.lease.root.Stat(lfw.lease.base)
+			fi, er := lfw.entry.root.Stat(lfw.entry.path)
 			if er == nil {
 				mode := fi.Mode()
 				lfw.fileMode = &mode
-				er = lfw.lease.root.Chmod(lfw.lease.base, mode|0222)
+				er = chmodRootEntry(lfw.entry, mode|0222)
 				if er == nil {
-					file, err = lfw.lease.root.OpenFile(lfw.lease.base, os.O_WRONLY, 0)
+					file, err = openRootEntryWriteFile(lfw.entry)
 				}
 			}
 		}
 		if err != nil {
-			return 0, errors.Wrapf(err, "failed to open %s", lfw.lease.base)
+			return 0, errors.Wrapf(err, "failed to open %s", lfw.entry.path)
 		}
 		lfw.f = file
 	}
@@ -344,7 +350,7 @@ func (lfw *rootLazyFileWriter) Close() error {
 		err = lfw.f.Close()
 	}
 	if err == nil && lfw.fileMode != nil {
-		err = lfw.lease.root.Chmod(lfw.lease.base, *lfw.fileMode)
+		err = chmodRootEntry(lfw.entry, *lfw.fileMode)
 	}
 	return err
 }

--- a/rootdiskwriter_unix.go
+++ b/rootdiskwriter_unix.go
@@ -25,21 +25,33 @@ func rewriteRootEntryMetadata(entry *RootEntry, stat *types.Stat) error {
 		return entry.ChtimesNoFollow(mtime, mtime)
 	}
 
-	if err := entry.ChmodNoFollow(os.FileMode(stat.Mode)); err != nil {
-		if !errors.Is(err, syscall.ENOSYS) && !errors.Is(err, syscall.EOPNOTSUPP) {
-			return errors.WithStack(err)
-		}
-		if err := entry.root.Chmod(entry.path, os.FileMode(stat.Mode)); err != nil {
-			return errors.WithStack(err)
-		}
+	if err := chmodRootEntry(entry, os.FileMode(stat.Mode)); err != nil {
+		return err
 	}
-	if err := entry.ChtimesNoFollow(mtime, mtime); err != nil {
-		return errors.WithStack(err)
-	}
+	return entry.ChtimesNoFollow(mtime, mtime)
+}
 
-	return nil
+func chtimesRootEntry(entry *RootEntry, un int64) error {
+	t := time.Unix(0, un)
+	return entry.ChtimesNoFollow(t, t)
 }
 
 func openRootEntryFile(entry *RootEntry, mode os.FileMode) (*os.File, error) {
 	return entry.OpenFileNoFollow(os.O_CREATE|os.O_WRONLY, mode)
+}
+
+func openRootEntryWriteFile(entry *RootEntry) (*os.File, error) {
+	return entry.OpenFileNoFollow(os.O_WRONLY, 0)
+}
+
+func chmodRootEntry(entry *RootEntry, mode os.FileMode) error {
+	if err := entry.ChmodNoFollow(mode); err != nil {
+		if !errors.Is(err, syscall.ENOSYS) && !errors.Is(err, syscall.EOPNOTSUPP) {
+			return errors.WithStack(err)
+		}
+		if err := entry.root.Chmod(entry.path, mode); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
 }

--- a/rootdiskwriter_unix.go
+++ b/rootdiskwriter_unix.go
@@ -4,30 +4,42 @@ package fsutil
 
 import (
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/tonistiigi/fsutil/types"
 )
 
-func rewriteRootMetadata(root Root, p string, stat *types.Stat) error {
+func rewriteRootEntryMetadata(entry *RootEntry, stat *types.Stat) error {
 	for key, value := range stat.Xattrs {
-		root.LSetxattr(p, key, value, 0)
+		_ = entry.LSetxattr(key, value, 0)
 	}
 
-	if err := root.Lchown(p, int(stat.Uid), int(stat.Gid)); err != nil {
+	if err := entry.Lchown(int(stat.Uid), int(stat.Gid)); err != nil {
 		return errors.WithStack(err)
 	}
 
+	mtime := time.Unix(0, stat.ModTime)
 	if os.FileMode(stat.Mode)&os.ModeSymlink != 0 {
-		return root.LChtimes(p, time.Unix(0, stat.ModTime))
+		return entry.ChtimesNoFollow(mtime, mtime)
 	}
-	if err := root.Chmod(p, os.FileMode(stat.Mode)); err != nil {
+
+	if err := entry.ChmodNoFollow(os.FileMode(stat.Mode)); err != nil {
+		if !errors.Is(err, syscall.ENOSYS) && !errors.Is(err, syscall.EOPNOTSUPP) {
+			return errors.WithStack(err)
+		}
+		if err := entry.root.Chmod(entry.path, os.FileMode(stat.Mode)); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	if err := entry.ChtimesNoFollow(mtime, mtime); err != nil {
 		return errors.WithStack(err)
-	}
-	if err := rootChtimes(root, p, stat.ModTime); err != nil {
-		return err
 	}
 
 	return nil
+}
+
+func openRootEntryFile(entry *RootEntry, mode os.FileMode) (*os.File, error) {
+	return entry.OpenFileNoFollow(os.O_CREATE|os.O_WRONLY, mode)
 }

--- a/rootdiskwriter_unix_test.go
+++ b/rootdiskwriter_unix_test.go
@@ -1,0 +1,52 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package fsutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonistiigi/fsutil/types"
+)
+
+func TestRootDiskWriterSymlinkMetadata(t *testing.T) {
+	dest := t.TempDir()
+	target := filepath.Join(dest, "target")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0600))
+
+	targetTime := time.Unix(1000, 0)
+	linkTime := time.Unix(2000, 0)
+	require.NoError(t, os.Chtimes(target, targetTime, targetTime))
+
+	osroot, err := os.OpenRoot(dest)
+	require.NoError(t, err)
+	destRoot := NewRoot(osroot)
+	defer destRoot.Close()
+
+	dw, err := NewRootDiskWriter(context.TODO(), destRoot, DiskWriterOpt{
+		SyncDataCb: noOpWriteTo,
+	})
+	require.NoError(t, err)
+
+	stat := &types.Stat{
+		Mode:     uint32(os.ModeSymlink | 0777),
+		Linkname: "target",
+		Uid:      uint32(os.Getuid()),
+		Gid:      uint32(os.Getgid()),
+		ModTime:  linkTime.UnixNano(),
+	}
+	require.NoError(t, dw.HandleChange(ChangeKindAdd, "link", &StatInfo{stat}, nil))
+	require.NoError(t, dw.Wait(context.Background()))
+
+	linkFi, err := os.Lstat(filepath.Join(dest, "link"))
+	require.NoError(t, err)
+	require.Equal(t, linkTime, linkFi.ModTime())
+
+	targetFi, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, targetTime, targetFi.ModTime())
+}

--- a/rootdiskwriter_windows.go
+++ b/rootdiskwriter_windows.go
@@ -13,7 +13,7 @@ func rewriteRootEntryMetadata(entry *RootEntry, stat *types.Stat) error {
 	if _, err := entry.Parent(); err != nil {
 		return err
 	}
-	return entry.root.LChtimes(entry.path, time.Unix(0, stat.ModTime))
+	return chtimesRootEntry(entry, stat.ModTime)
 }
 
 func openRootEntryFile(entry *RootEntry, mode os.FileMode) (*os.File, error) {
@@ -21,4 +21,25 @@ func openRootEntryFile(entry *RootEntry, mode os.FileMode) (*os.File, error) {
 		return nil, err
 	}
 	return entry.root.OpenFile(entry.path, os.O_CREATE|os.O_WRONLY, mode)
+}
+
+func openRootEntryWriteFile(entry *RootEntry) (*os.File, error) {
+	if _, err := entry.Parent(); err != nil {
+		return nil, err
+	}
+	return entry.root.OpenFile(entry.path, os.O_WRONLY, 0)
+}
+
+func chmodRootEntry(entry *RootEntry, mode os.FileMode) error {
+	if _, err := entry.Parent(); err != nil {
+		return err
+	}
+	return entry.root.Chmod(entry.path, mode)
+}
+
+func chtimesRootEntry(entry *RootEntry, un int64) error {
+	if _, err := entry.Parent(); err != nil {
+		return err
+	}
+	return entry.root.LChtimes(entry.path, time.Unix(0, un))
 }

--- a/rootdiskwriter_windows.go
+++ b/rootdiskwriter_windows.go
@@ -3,11 +3,22 @@
 package fsutil
 
 import (
+	"os"
 	"time"
 
 	"github.com/tonistiigi/fsutil/types"
 )
 
-func rewriteRootMetadata(root Root, p string, stat *types.Stat) error {
-	return root.LChtimes(p, time.Unix(0, stat.ModTime))
+func rewriteRootEntryMetadata(entry *RootEntry, stat *types.Stat) error {
+	if _, err := entry.Parent(); err != nil {
+		return err
+	}
+	return entry.root.LChtimes(entry.path, time.Unix(0, stat.ModTime))
+}
+
+func openRootEntryFile(entry *RootEntry, mode os.FileMode) (*os.File, error) {
+	if _, err := entry.Parent(); err != nil {
+		return nil, err
+	}
+	return entry.root.OpenFile(entry.path, os.O_CREATE|os.O_WRONLY, mode)
 }


### PR DESCRIPTION
needs #277 

Route RootDiskWriter's async lazy writer through RootEntry so cached parent roots still use final-component entry operations for opening, chmod retries, and mtime restore.

Keep the Windows helper path on the existing Root operations while sharing the same entry-based lazy writer structure.